### PR TITLE
changed solc to 0.8.24, added evm_version london

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,8 @@ src = "src"
 out = "out"
 libs = ["lib"]
 via_ir = true
-solc = "0.8.19"
+solc = "0.8.24"
+evm_version = "london"
 fs_permissions = [
     { access = "read-write", path = "./deployments" },
     { access = "read", path = "./out" },


### PR DESCRIPTION
still no PUSH0 because we target to london, but build is 25% faster