### PR TITLE
fix: subgraph proof stats model & fix in DealMatcherClient & fix match counters for DealExplorerClient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,18 +89,11 @@ deploy-contracts%: ## Deploy contracts to ...
 
 	@echo "\033[0;32mSuccess! Contracts deployed to $* chain.\033[0m"
 
-create-pure-market-local: ## Create market on a local blockchain with Anvil mnemonic
+create-pure-market-local: ## Create market on a local blockchain with Anvil mnemonic (do not use it with stage,dar,kras)
 	@make verify-command program=forge
 	@cd ts-client && npm run create-pure-market-script
 
 	@echo "\033[0;32mSuccess! Pure market created on local chain - check it out.\033[0m"
-
-create-pure-market-%: ## Create market on for a stand...
-	@make verify-command program=forge
-	@CONTRACTS_ENV_NAME=$* forge script script/CreateMarket.s.sol --rpc-url $*  \
-	--private-key $(PRIVATE_KEY) --broadcast
-
-	@echo "\033[0;32mSuccess! Pure market created on $* chain - check it out.\033[0m"
 
 help: ## List makefile targets
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -25,7 +25,7 @@ type GraphNetwork @entity {
   minRequiredProofsPerEpoch: Int
 }
 
-type Token @entity(immutable: true) {
+type Token @entity {
   id: ID!  # Token Address
   symbol: String!
   decimals: Int!
@@ -150,13 +150,13 @@ type ComputeUnit @entity {
 }
 
 # ---- Deal Contract ----
-type DealToEffector @entity(immutable: true) {
+type DealToEffector @entity {
     id: ID! # Set to `deal.id.concat(effector.id)`
     deal: Deal!
     effector: Effector!
 }
 
-type DealToPeer @entity(immutable: true) {
+type DealToPeer @entity {
     id: ID! # Set to `deal.id.concat(peer.id)`
     deal: Deal!
     peer: Peer!
@@ -169,7 +169,7 @@ TODO: deprecate.
 To add possibility to filter already joined peers into a Deal from perspective of an Offer
 (protocol does not allow more than one CU per peer for the same Deal).
 """
-type DealToJoinedOfferPeer @entity(immutable: true) {
+type DealToJoinedOfferPeer @entity {
     id: ID! # Set to `deal.id.concat(offer.id.concat(peer.id))`
     deal: Deal!
     offer: Offer!  # search offers initially using this fk relation.
@@ -177,7 +177,7 @@ type DealToJoinedOfferPeer @entity(immutable: true) {
 }
 
 "It represents m2m b/w deal and provider in context of access list."
-type DealToProvidersAccess @entity(immutable: true) {
+type DealToProvidersAccess @entity {
   id: ID! # Set to `deal.id.concat(provider.id)`
   deal: Deal!
   provider: Provider!
@@ -225,7 +225,7 @@ enum CapacityCommitmentStatus {
   Removed
 }
 
-type CapacityCommitmentToComputeUnit @entity(immutable: true) {
+type CapacityCommitmentToComputeUnit @entity {
   id: ID! # Set to `capacityCommitment.id.concat(computeUnit.id)`
   capacityCommitment: CapacityCommitment!
   computeUnit: ComputeUnit!
@@ -270,7 +270,7 @@ type CapacityCommitment @entity {
   provider: Provider!
 }
 
-type SubmittedProof @entity(immutable: true) {
+type SubmittedProof @entity {
   "Id here is a transaction hash."
   id: ID!
   capacityCommitment: CapacityCommitment!

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -160,6 +160,8 @@ type DealToPeer @entity(immutable: true) {
     id: ID! # Set to `deal.id.concat(peer.id)`
     deal: Deal!
     peer: Peer!
+    "Helper field to understand number of connections."
+    connections: Int!
 }
 
 """

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -205,6 +205,9 @@ type Deal @entity {
   withdrawalSum: BigInt!
   depositedSum: BigInt!  # calculated from the withdraw() [no rewards withdraw].
   maxPaidEpoch: BigInt
+  registeredWorkersCurrentCount: Int!
+  "Currently matched workers == matched compute units."
+  matchedWorkersCurrentCount: Int!
 
   "I.e. Matching Result (Figma)."
   addedComputeUnits: [ComputeUnit!] @derivedFrom(field: "deal")

--- a/subgraph/src/mappings/capacity.ts
+++ b/subgraph/src/mappings/capacity.ts
@@ -40,13 +40,13 @@ import {log} from "@graphprotocol/graph-ts/index";
 
 
 export function handleWhitelistAccessGranted(event: WhitelistAccessGranted): void {
-  let provider = Provider.load(event.params.account.toHex()) as Provider;
+  let provider = Provider.load(event.params.account.toHexString()) as Provider;
   provider.approved = true;
   provider.save();
 }
 
 export function handleWhitelistAccessRevoked(event: WhitelistAccessRevoked): void {
-  let provider = Provider.load(event.params.account.toHex()) as Provider;
+  let provider = Provider.load(event.params.account.toHexString()) as Provider;
   provider.approved = false;
   provider.save();
 }
@@ -62,11 +62,11 @@ export function handleInitialized(event: Initialized): void {
 export function handleCommitmentCreated(event: CommitmentCreated): void {
   // TODO: rm those logs if phantom error does not occur.
   log.info("[handleCommitmentCreated] Start...", []);
-  let commitment = new CapacityCommitment(event.params.commitmentId.toHex());
-  log.info("event.params.commitmentId.toHex(): {}", [event.params.commitmentId.toHex()]);
-  log.info("event.params.peerId.toHex(): {}", [event.params.peerId.toHex()]);
+  let commitment = new CapacityCommitment(event.params.commitmentId.toHexString());
+  log.info("event.params.commitmentId.toHexString(): {}", [event.params.commitmentId.toHexString()]);
+  log.info("event.params.peerId.toHexString(): {}", [event.params.peerId.toHexString()]);
   // Load or create peer.
-  let peer = Peer.load(event.params.peerId.toHex()) as Peer;
+  let peer = Peer.load(event.params.peerId.toHexString()) as Peer;
   log.info("peer loaded successfully: {}", [peer.id]);
 
   commitment.peer = peer.id
@@ -104,7 +104,7 @@ export function handleCommitmentCreated(event: CommitmentCreated): void {
 // It is supposed that collateral deposited at the same time as commitment activated
 //  (the same tx).
 export function handleCommitmentActivated(event: CommitmentActivated): void {
-  let commitment = CapacityCommitment.load(event.params.commitmentId.toHex()) as CapacityCommitment;
+  let commitment = CapacityCommitment.load(event.params.commitmentId.toHexString()) as CapacityCommitment;
   commitment.status = CapacityCommitmentStatus.WaitStart
   commitment.startEpoch = event.params.startEpoch
   commitment.endEpoch = event.params.endEpoch
@@ -112,7 +112,7 @@ export function handleCommitmentActivated(event: CommitmentActivated): void {
 
   commitment.computeUnitsCount = event.params.unitIds.length
   for (let i=0; i < event.params.unitIds.length; i++) {
-    const computeUnitId = event.params.unitIds[i].toHex()
+    const computeUnitId = event.params.unitIds[i].toHexString()
     // We rely on contract logic that it is not possible to emit event with not existing CUs.
     //  Also, we relay that previously we save computeUnitId successfully in prev. handler.
     const computeUnit = ComputeUnit.load(computeUnitId) as ComputeUnit
@@ -137,7 +137,7 @@ export function handleCommitmentActivated(event: CommitmentActivated): void {
   commitment.nextCCFailedEpoch = _calculatedFailedEpoch
   commitment.save()
 
-  let peer = Peer.load(event.params.peerId.toHex()) as Peer;
+  let peer = Peer.load(event.params.peerId.toHexString()) as Peer;
   peer.currentCCCollateralDepositedAt = event.params.startEpoch;
   peer.currentCCEndEpoch = event.params.endEpoch;
   peer.currentCCNextCCFailedEpoch = _calculatedFailedEpoch;
@@ -145,13 +145,13 @@ export function handleCommitmentActivated(event: CommitmentActivated): void {
 }
 
 export function handleCollateralDeposited(event: CollateralDeposited): void {
-  let commitment = CapacityCommitment.load(event.params.commitmentId.toHex()) as CapacityCommitment;
+  let commitment = CapacityCommitment.load(event.params.commitmentId.toHexString()) as CapacityCommitment;
   commitment.totalCollateral = event.params.totalCollateral;
   commitment.save()
 }
 
 export function handleCommitmentRemoved(event: CommitmentRemoved): void {
-  let commitment = CapacityCommitment.load(event.params.commitmentId.toHex()) as CapacityCommitment;
+  let commitment = CapacityCommitment.load(event.params.commitmentId.toHexString()) as CapacityCommitment;
   commitment.deleted = true;
   commitment.save();
 
@@ -163,7 +163,7 @@ export function handleCommitmentRemoved(event: CommitmentRemoved): void {
 }
 
 export function handleCommitmentFinished(event: CommitmentFinished): void {
-  let commitment = CapacityCommitment.load(event.params.commitmentId.toHex()) as CapacityCommitment;
+  let commitment = CapacityCommitment.load(event.params.commitmentId.toHexString()) as CapacityCommitment;
   commitment.status = CapacityCommitmentStatus.Removed;
   commitment.save();
 
@@ -176,7 +176,7 @@ export function handleCommitmentFinished(event: CommitmentFinished): void {
 
 export function handleCommitmentStatsUpdated(event: CommitmentStatsUpdated): void {
   // Handle current commitment stats.
-  let commitment = CapacityCommitment.load(event.params.commitmentId.toHex()) as CapacityCommitment;
+  let commitment = CapacityCommitment.load(event.params.commitmentId.toHexString()) as CapacityCommitment;
 
   commitment.totalCUFailCount = event.params.totalCUFailCount.toI32()
   commitment.exitedUnitCount = event.params.exitedUnitCount.toI32()
@@ -233,7 +233,7 @@ export function handleCommitmentStatsUpdated(event: CommitmentStatsUpdated): voi
 // Use this event to only check activation/deactivation for the exact unit.
 // Do not update commitment.activeUnitCount as it is updated in handleCommitmentStatsUpdated.
 export function handleUnitActivated(event: UnitActivated): void {
-  let computeUnit = ComputeUnit.load(event.params.unitId.toHex()) as ComputeUnit;
+  let computeUnit = ComputeUnit.load(event.params.unitId.toHexString()) as ComputeUnit;
   let peer = Peer.load(computeUnit.peer) as Peer;
 
   peer.computeUnitsInCapacityCommitment = peer.computeUnitsInCapacityCommitment + 1;
@@ -243,7 +243,7 @@ export function handleUnitActivated(event: UnitActivated): void {
 // Use this event to only check activation/deactivation for the exact unit.
 // Do not update commitment.activeUnitCount as it is updated in handleCommitmentStatsUpdated.
 export function handleUnitDeactivated(event: UnitDeactivated): void {
-  let computeUnit = ComputeUnit.load(event.params.unitId.toHex()) as ComputeUnit;
+  let computeUnit = ComputeUnit.load(event.params.unitId.toHexString()) as ComputeUnit;
   let peer = Peer.load(computeUnit.peer) as Peer;
 
   peer.computeUnitsInCapacityCommitment = peer.computeUnitsInCapacityCommitment - 1;
@@ -251,9 +251,9 @@ export function handleUnitDeactivated(event: UnitDeactivated): void {
 }
 
 export function handleProofSubmitted(event: ProofSubmitted): void {
-  let proofSubmitted = new SubmittedProof(event.transaction.hash.toHex());
-  let capacityCommitment = CapacityCommitment.load(event.params.commitmentId.toHex()) as CapacityCommitment;
-  let computeUnit = ComputeUnit.load(event.params.unitId.toHex()) as ComputeUnit;
+  let proofSubmitted = new SubmittedProof(event.transaction.hash.toHexString());
+  let capacityCommitment = CapacityCommitment.load(event.params.commitmentId.toHexString()) as CapacityCommitment;
+  let computeUnit = ComputeUnit.load(event.params.unitId.toHexString()) as ComputeUnit;
   const provider = Provider.load(computeUnit.provider) as Provider;
   let graphNetwork = createOrLoadGraphNetwork();
   const currentEpoch = calculateEpoch(
@@ -297,7 +297,7 @@ export function handleProofSubmitted(event: ProofSubmitted): void {
 }
 
 export function handleRewardWithdrawn(event: RewardWithdrawn): void {
-  let capacityCommitment = CapacityCommitment.load(event.params.commitmentId.toHex()) as CapacityCommitment;
+  let capacityCommitment = CapacityCommitment.load(event.params.commitmentId.toHexString()) as CapacityCommitment;
   capacityCommitment.rewardWithdrawn = capacityCommitment.rewardWithdrawn.plus(event.params.amount)
   capacityCommitment.save()
 }

--- a/subgraph/src/mappings/deal-factory.ts
+++ b/subgraph/src/mappings/deal-factory.ts
@@ -23,11 +23,11 @@ import { AppCID, formatAddress, getEffectorCID, parseEffectors } from "./utils";
 
 // ---- Factory Events ----
 export function handleDealCreated(event: DealCreated): void {
-  const dealAddress = formatAddress(event.params.deal);
-  log.info("[handleDealCreated] New deal created: {} by: {}", [
-    event.params.owner.toString(),
-    dealAddress.toString(),
+  log.info("[handleDealCreated] Create new Deal with address: {} with owner: {}", [
+    event.params.deal.toHexString(),
+    event.params.owner.toHexString()
   ]);
+  const dealAddress = formatAddress(event.params.deal);
 
   const deal = new Deal(dealAddress);
   let graphNetwork = createOrLoadGraphNetwork();

--- a/subgraph/src/mappings/deal-factory.ts
+++ b/subgraph/src/mappings/deal-factory.ts
@@ -43,6 +43,8 @@ export function handleDealCreated(event: DealCreated): void {
   deal.appCID = getEffectorCID(appCID);
   deal.withdrawalSum = ZERO_BIG_INT;
   deal.depositedSum = ZERO_BIG_INT;
+  deal.registeredWorkersCurrentCount = 0;
+  deal.matchedWorkersCurrentCount = 0;
 
   // Perform provider access lists (whitelist, blacklist or non).
   deal.providersAccessType = event.params.providersAccessType_;

--- a/subgraph/src/mappings/deal.ts
+++ b/subgraph/src/mappings/deal.ts
@@ -67,8 +67,17 @@ export function handleWorkerIdUpdated(event: WorkerIdUpdated): void {
   let computeUnit = ComputeUnit.load(
     event.params.computeUnitId.toHex(),
   ) as ComputeUnit;
-  computeUnit.workerId = event.params.workerId.toHex();
+  let deal = Deal.load(formatAddress(event.address)) as Deal;
+
+  computeUnit.workerId = event.params.workerId.toHexString();
   computeUnit.save();
+
+  // Update stats below.
+  // Check that worker already counted and counter should not be updated.
+  if (computeUnit.workerId == null) {
+    deal.registeredWorkersCurrentCount = deal.registeredWorkersCurrentCount + 1;
+    deal.save();
+  }
 }
 
 export function handleProviderAddedToAccessList(event: ProviderAddedToAccessList): void {

--- a/subgraph/src/mappings/deal.ts
+++ b/subgraph/src/mappings/deal.ts
@@ -16,25 +16,25 @@ import {
 import {store} from "@graphprotocol/graph-ts";
 
 export function handleDeposited(event: Deposited): void {
-  let deal = Deal.load(event.address.toHex()) as Deal;
+  let deal = Deal.load(formatAddress(event.address)) as Deal;
   deal.depositedSum = deal.depositedSum.plus(event.params.amount);
   deal.save();
 }
 
 export function handleWithdrawn(event: Withdrawn): void {
-  let deal = Deal.load(event.address.toHex()) as Deal;
+  let deal = Deal.load(formatAddress(event.address)) as Deal;
   deal.withdrawalSum = deal.withdrawalSum.plus(event.params.amount);
   deal.save();
 }
 
 export function handleMaxPaidEpochUpdated(event: MaxPaidEpochUpdated): void {
-  let deal = Deal.load(event.address.toHex()) as Deal;
+  let deal = Deal.load(formatAddress(event.address)) as Deal;
   deal.maxPaidEpoch = event.params.maxPaidEpoch;
   deal.save();
 }
 
 export function handleAppCIDChanged(event: AppCIDChanged): void {
-  let deal = Deal.load(event.address.toHex()) as Deal;
+  let deal = Deal.load(formatAddress(event.address)) as Deal;
   const cid = changetype<AppCID>(event.params.newAppCID);
   deal.appCID = getEffectorCID(cid);
   deal.save();
@@ -43,7 +43,7 @@ export function handleAppCIDChanged(event: AppCIDChanged): void {
 // Joined to Deal.
 // Note, in Market we also handle handleComputeUnitAddedToDeal.
 export function handleComputeUnitJoined(event: ComputeUnitJoined): void {
-  const deal = Deal.load(event.address.toHex()) as Deal;
+  const deal = Deal.load(formatAddress(event.address)) as Deal;
 
   let computeUnit = ComputeUnit.load(
     event.params.unitId.toHex(),

--- a/subgraph/src/mappings/deal.ts
+++ b/subgraph/src/mappings/deal.ts
@@ -46,7 +46,7 @@ export function handleComputeUnitJoined(event: ComputeUnitJoined): void {
   const deal = Deal.load(formatAddress(event.address)) as Deal;
 
   let computeUnit = ComputeUnit.load(
-    event.params.unitId.toHex(),
+    event.params.unitId.toHexString(),
   ) as ComputeUnit;
   computeUnit.deal = deal.id;
   computeUnit.save();
@@ -56,7 +56,7 @@ export function handleComputeUnitJoined(event: ComputeUnitJoined): void {
 // Note, in Market we also handle ComputeUnitRemovedFromDeal.
 export function handleComputeUnitRemoved(event: ComputeUnitRemoved): void {
   let computeUnit = ComputeUnit.load(
-    event.params.unitId.toHex(),
+    event.params.unitId.toHexString(),
   ) as ComputeUnit;
   computeUnit.deal = null;
   computeUnit.save();
@@ -65,7 +65,7 @@ export function handleComputeUnitRemoved(event: ComputeUnitRemoved): void {
 // Link workerId to CU.
 export function handleWorkerIdUpdated(event: WorkerIdUpdated): void {
   let computeUnit = ComputeUnit.load(
-    event.params.computeUnitId.toHex(),
+    event.params.computeUnitId.toHexString(),
   ) as ComputeUnit;
   let deal = Deal.load(formatAddress(event.address)) as Deal;
 

--- a/subgraph/src/mappings/market.ts
+++ b/subgraph/src/mappings/market.ts
@@ -227,9 +227,11 @@ export function handleComputeUnitAddedToDeal(
   let peer = Peer.load(event.params.peerId.toHex()) as Peer;
   const offer = Offer.load(peer.offer) as Offer;
   const provider = Provider.load(offer.provider) as Provider;
+  const deal = Deal.load(formatAddress(event.params.deal)) as Deal;
 
-  createOrLoadDealToPeer(event.address.toHex(), peer.id);
-  createOrLoadDealToJoinedOfferPeer(event.address.toHex(), offer.id, peer.id);
+  createOrLoadDealToPeer(deal.id, peer.id);
+  createOrLoadDealToJoinedOfferPeer(deal.id, offer.id, peer.id);
+
   peer.isAnyJoinedDeals = true;
 
   // Upd stats.

--- a/subgraph/src/mappings/market.ts
+++ b/subgraph/src/mappings/market.ts
@@ -278,7 +278,9 @@ export function handleComputeUnitRemovedFromDeal(
 
   // Upd stats.
   deal.matchedWorkersCurrentCount = deal.matchedWorkersCurrentCount - 1;
-  if (computeUnit.workerId == null) {
+  if (!computeUnit.workerId == null) {
+    computeUnit.workerId = null;
+    computeUnit.save();
     deal.registeredWorkersCurrentCount = deal.registeredWorkersCurrentCount - 1;
   }
   deal.save();

--- a/subgraph/src/mappings/market.ts
+++ b/subgraph/src/mappings/market.ts
@@ -92,10 +92,10 @@ export function handleMarketOfferRegistered(
   // - emit PeerCreated(offerId, peer.peerId);
   // - emit ComputeUnitCreated(offerId, peerId, unitId);
 
-  const provider = Provider.load(event.params.provider.toHex()) as Provider;
+  const provider = Provider.load(event.params.provider.toHexString()) as Provider;
 
   // Create Offer.
-  const offer = new Offer(event.params.offerId.toHex());
+  const offer = new Offer(event.params.offerId.toHexString());
   offer.provider = provider.id;
   offer.paymentToken = createOrLoadToken(event.params.paymentToken).id;
   offer.pricePerEpoch = event.params.minPricePerWorkerEpoch;
@@ -127,12 +127,12 @@ export function handleComputeUnitCreated(event: ComputeUnitCreated): void {
   // Parent events:
   // - emit PeerCreated(offerId, peer.peerId);
   // - emit MarketOfferRegistered
-  let peer = Peer.load(event.params.peerId.toHex()) as Peer;
+  let peer = Peer.load(event.params.peerId.toHexString()) as Peer;
   const offer = Offer.load(peer.offer) as Offer;
   const provider = Provider.load(offer.provider) as Provider;
 
   // Since handlePeerCreated could not work with this handler, this logic moved here.
-  const computeUnit = new ComputeUnit(event.params.unitId.toHex());
+  const computeUnit = new ComputeUnit(event.params.unitId.toHexString());
   computeUnit.provider = peer.provider;
   computeUnit.peer = peer.id;
   computeUnit.submittedProofsCount = 0;
@@ -155,8 +155,8 @@ export function handleComputeUnitCreated(event: ComputeUnitCreated): void {
 
 // It updates Peer and Offer.
 export function handlePeerCreated(event: PeerCreated): void {
-  const peer = new Peer(event.params.peerId.toHex());
-  const offer = Offer.load(event.params.offerId.toHex()) as Offer;
+  const peer = new Peer(event.params.peerId.toHexString());
+  const offer = Offer.load(event.params.offerId.toHexString()) as Offer;
   const provider = Provider.load(offer.provider) as Provider;
   provider.peerCount = provider.peerCount + 1;
   provider.save();
@@ -177,19 +177,19 @@ export function handlePeerCreated(event: PeerCreated): void {
 export function handleMinPricePerEpochUpdated(
   event: MinPricePerEpochUpdated,
 ): void {
-  const offer = Offer.load(event.params.offerId.toHex()) as Offer;
+  const offer = Offer.load(event.params.offerId.toHexString()) as Offer;
   offer.pricePerEpoch = event.params.minPricePerWorkerEpoch;
   offer.save();
 }
 
 export function handlePaymentTokenUpdated(event: PaymentTokenUpdated): void {
-  const offer = Offer.load(event.params.offerId.toHex()) as Offer;
+  const offer = Offer.load(event.params.offerId.toHexString()) as Offer;
   offer.paymentToken = createOrLoadToken(event.params.paymentToken).id;
   offer.save();
 }
 
 export function handleEffectorAdded(event: EffectorAdded): void {
-  const offer = Offer.load(event.params.offerId.toHex()) as Offer;
+  const offer = Offer.load(event.params.offerId.toHexString()) as Offer;
   const appCID = changetype<AppCID>(event.params.effector);
   const cid = getEffectorCID(appCID);
   const effector = createOrLoadEffector(cid);
@@ -204,7 +204,7 @@ export function handleEffectorAdded(event: EffectorAdded): void {
 }
 
 export function handleEffectorRemoved(event: EffectorRemoved): void {
-  const offer = Offer.load(event.params.offerId.toHex()) as Offer;
+  const offer = Offer.load(event.params.offerId.toHexString()) as Offer;
   const appCID = changetype<AppCID>(event.params.effector);
   const cidToRemove = getEffectorCID(appCID);
   const effector = createOrLoadEffector(cidToRemove);
@@ -224,7 +224,7 @@ export function handleComputeUnitAddedToDeal(
   event: ComputeUnitAddedToDeal,
 ): void {
   // Call the contract to extract peerId of the computeUnit.
-  let peer = Peer.load(event.params.peerId.toHex()) as Peer;
+  let peer = Peer.load(event.params.peerId.toHexString()) as Peer;
   const offer = Offer.load(peer.offer) as Offer;
   const provider = Provider.load(offer.provider) as Provider;
   let deal = Deal.load(formatAddress(event.params.deal)) as Deal;
@@ -258,10 +258,10 @@ export function handleComputeUnitRemovedFromDeal(
   event: ComputeUnitRemovedFromDeal,
 ): void {
   // Call the contract to extract peerId of the computeUnit.
-  let peer = Peer.load(event.params.peerId.toHex()) as Peer;
+  let peer = Peer.load(event.params.peerId.toHexString()) as Peer;
   const offer = Offer.load(peer.offer) as Offer;
   const provider = Provider.load(offer.provider) as Provider;
-  let computeUnit = ComputeUnit.load(event.params.unitId.toHex()) as ComputeUnit;
+  let computeUnit = ComputeUnit.load(event.params.unitId.toHexString()) as ComputeUnit;
   let deal = Deal.load(formatAddress(event.params.deal)) as Deal;
 
   const dealToPeerReturn = createOrLoadDealToPeer(deal.id, peer.id);

--- a/subgraph/src/mappings/utils.ts
+++ b/subgraph/src/mappings/utils.ts
@@ -35,11 +35,11 @@ export function parseEffectors(effectors: Array<AppCID>): Array<string> {
  >>> changetype<AppCID>(event.params.effector)
  */
 export function getEffectorCID(effectorTuple: AppCID): string {
-  const cid = effectorTuple.prefixes.toString() + effectorTuple.hash.toString();
+  const cid = effectorTuple.prefixes.toHexString() + effectorTuple.hash.toHexString();
   log.info("[getEffectorCID] Extract CID from effector: {}", [cid]);
   return cid;
 }
 
 export function formatAddress(address: Address): string {
-  return address.toHex().toLowerCase();
+  return address.toHexString().toLowerCase();
 }

--- a/subgraph/src/models.ts
+++ b/subgraph/src/models.ts
@@ -11,6 +11,7 @@ import {
   CapacityCommitmentToComputeUnit,
   CapacityCommitmentStatsPerEpoch,
   ComputeUnitPerEpochStat,
+  ComputeUnit,
 } from "../generated/schema";
 import {Address, BigInt, Bytes} from "@graphprotocol/graph-ts";
 import { getTokenDecimals, getTokenSymbol } from "./contracts";
@@ -250,8 +251,11 @@ export function createOrLoadComputeUnitPerEpochStat(computeUnitId: string, epoch
   let entity = ComputeUnitPerEpochStat.load(concattedIds);
 
   if (entity == null) {
+    let computeUnit = ComputeUnit.load(computeUnitId) as ComputeUnit;
     entity = new ComputeUnitPerEpochStat(concattedIds)
     entity.submittedProofsCount = 0;
+    entity.epoch = BigInt.fromString(epoch);
+    entity.computeUnit = computeUnit.id;
     entity.save()
   }
   return entity as ComputeUnitPerEpochStat

--- a/subgraph/src/models.ts
+++ b/subgraph/src/models.ts
@@ -124,20 +124,34 @@ export function createOrLoadDealEffector(
   return entity as DealToEffector;
 }
 
+// Subgprah compiler does not support return mapping/dict,
+//  thus, class is presented.
+class CreateOrLoadDealToPeerReturn {
+  public created: boolean;
+  public entity: DealToPeer;
+  constructor(entity: DealToPeer, created: boolean) {
+    this.created = created;
+    this.entity = entity;
+  }
+}
+
 export function createOrLoadDealToPeer(
   dealId: string,
   peerId: string,
-): DealToPeer {
+): CreateOrLoadDealToPeerReturn {
   const concattedIds = dealId.concat(peerId);
   let entity = DealToPeer.load(concattedIds);
+  let created = false;
 
   if (entity == null) {
     entity = new DealToPeer(concattedIds);
     entity.deal = dealId;
     entity.peer = peerId;
+    entity.connections = 1;
     entity.save();
+    created = true;
   }
-  return entity as DealToPeer;
+  return new CreateOrLoadDealToPeerReturn(entity, created);
 }
 
 export function createOrLoadDealToJoinedOfferPeer(

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -15,7 +15,8 @@
     "codegen:matcherIndexerClient": "graphql-codegen --config codegen-deal-matcher-indexer.ts",
     "codegen:dealCliClient": "graphql-codegen --config codegen-deal-cli-indexer.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "create-pure-market-script": "vitest run create-pure-market.test"
   },
   "files": [
     "dist"

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -1,3 +1,5 @@
+// All main view methods consist of notice docstring to refer to Figma screen
+//  e.g. // @notice [Figma] Deal.
 // @dev There is a lot of "total: null," in the code - we await subgraph feature:
 //  return counter of filtration (currently 14.02.24 it is impossible).
 import { ethers } from "ethers";

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -636,10 +636,7 @@ export class DealExplorerClient {
         await this._dealRpcClient!.getFreeBalanceDealBatch([dealId])
       )[0];
       const effectors = serializeEffectors(deal.effectors);
-      const { whitelist, blacklist } = serializeDealProviderAccessLists(
-        deal.providersAccessType,
-        deal.providersAccessList,
-      );
+      const { whitelist, blacklist } = serializeDealProviderAccessLists(deal.providersAccessType, deal.providersAccessList);
       res = {
         ...serializeDealsShort(deal, { dealStatus, freeBalance }),
         pricePerWorkerEpoch: tokenValueToRounded(

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -327,7 +327,7 @@ export class DealExplorerClient {
       console.warn("Filter deals by status if not implemented.");
     }
     return await this._getDealsImpl(
-      { providerId: dealsByProviderFilter.providerId?.toLowerCase() },
+      { providerId: dealsByProviderFilter.providerId.toLowerCase() },
       offset,
       limit,
       orderBy,

--- a/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
@@ -903,12 +903,14 @@ export type ComputeUnit_OrderBy =
   | 'deal__createdAt'
   | 'deal__depositedSum'
   | 'deal__id'
+  | 'deal__matchedWorkersCurrentCount'
   | 'deal__maxPaidEpoch'
   | 'deal__maxWorkersPerProvider'
   | 'deal__minWorkers'
   | 'deal__owner'
   | 'deal__pricePerWorkerEpoch'
   | 'deal__providersAccessType'
+  | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
   | 'id'
@@ -945,6 +947,8 @@ export type Deal = {
   id: Scalars['ID']['output'];
   /** Many to many to access joined peers to maintain protocol restrictions */
   joinedPeers?: Maybe<Array<DealToPeer>>;
+  /** Currently matched workers == matched compute units. */
+  matchedWorkersCurrentCount: Scalars['Int']['output'];
   maxPaidEpoch?: Maybe<Scalars['BigInt']['output']>;
   maxWorkersPerProvider: Scalars['Int']['output'];
   minWorkers: Scalars['Int']['output'];
@@ -954,6 +958,7 @@ export type Deal = {
   providersAccessList?: Maybe<Array<DealToProvidersAccess>>;
   /** It represents AccessType of Deal contract. */
   providersAccessType: Scalars['Int']['output'];
+  registeredWorkersCurrentCount: Scalars['Int']['output'];
   targetWorkers: Scalars['Int']['output'];
   withdrawalSum: Scalars['BigInt']['output'];
 };
@@ -1064,12 +1069,14 @@ export type DealToEffector_OrderBy =
   | 'deal__createdAt'
   | 'deal__depositedSum'
   | 'deal__id'
+  | 'deal__matchedWorkersCurrentCount'
   | 'deal__maxPaidEpoch'
   | 'deal__maxWorkersPerProvider'
   | 'deal__minWorkers'
   | 'deal__owner'
   | 'deal__pricePerWorkerEpoch'
   | 'deal__providersAccessType'
+  | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
   | 'effector'
@@ -1175,12 +1182,14 @@ export type DealToJoinedOfferPeer_OrderBy =
   | 'deal__createdAt'
   | 'deal__depositedSum'
   | 'deal__id'
+  | 'deal__matchedWorkersCurrentCount'
   | 'deal__maxPaidEpoch'
   | 'deal__maxWorkersPerProvider'
   | 'deal__minWorkers'
   | 'deal__owner'
   | 'deal__pricePerWorkerEpoch'
   | 'deal__providersAccessType'
+  | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
   | 'id'
@@ -1271,12 +1280,14 @@ export type DealToPeer_OrderBy =
   | 'deal__createdAt'
   | 'deal__depositedSum'
   | 'deal__id'
+  | 'deal__matchedWorkersCurrentCount'
   | 'deal__maxPaidEpoch'
   | 'deal__maxWorkersPerProvider'
   | 'deal__minWorkers'
   | 'deal__owner'
   | 'deal__pricePerWorkerEpoch'
   | 'deal__providersAccessType'
+  | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
   | 'id'
@@ -1361,12 +1372,14 @@ export type DealToProvidersAccess_OrderBy =
   | 'deal__createdAt'
   | 'deal__depositedSum'
   | 'deal__id'
+  | 'deal__matchedWorkersCurrentCount'
   | 'deal__maxPaidEpoch'
   | 'deal__maxWorkersPerProvider'
   | 'deal__minWorkers'
   | 'deal__owner'
   | 'deal__pricePerWorkerEpoch'
   | 'deal__providersAccessType'
+  | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
   | 'id'
@@ -1431,6 +1444,14 @@ export type Deal_Filter = {
   id_not?: InputMaybe<Scalars['ID']['input']>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   joinedPeers_?: InputMaybe<DealToPeer_Filter>;
+  matchedWorkersCurrentCount?: InputMaybe<Scalars['Int']['input']>;
+  matchedWorkersCurrentCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  matchedWorkersCurrentCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  matchedWorkersCurrentCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  matchedWorkersCurrentCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  matchedWorkersCurrentCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  matchedWorkersCurrentCount_not?: InputMaybe<Scalars['Int']['input']>;
+  matchedWorkersCurrentCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   maxPaidEpoch?: InputMaybe<Scalars['BigInt']['input']>;
   maxPaidEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
   maxPaidEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -1514,6 +1535,14 @@ export type Deal_Filter = {
   providersAccessType_lte?: InputMaybe<Scalars['Int']['input']>;
   providersAccessType_not?: InputMaybe<Scalars['Int']['input']>;
   providersAccessType_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  registeredWorkersCurrentCount?: InputMaybe<Scalars['Int']['input']>;
+  registeredWorkersCurrentCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  registeredWorkersCurrentCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  registeredWorkersCurrentCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  registeredWorkersCurrentCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  registeredWorkersCurrentCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  registeredWorkersCurrentCount_not?: InputMaybe<Scalars['Int']['input']>;
+  registeredWorkersCurrentCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   targetWorkers?: InputMaybe<Scalars['Int']['input']>;
   targetWorkers_gt?: InputMaybe<Scalars['Int']['input']>;
   targetWorkers_gte?: InputMaybe<Scalars['Int']['input']>;
@@ -1540,6 +1569,7 @@ export type Deal_OrderBy =
   | 'effectors'
   | 'id'
   | 'joinedPeers'
+  | 'matchedWorkersCurrentCount'
   | 'maxPaidEpoch'
   | 'maxWorkersPerProvider'
   | 'minWorkers'
@@ -1551,6 +1581,7 @@ export type Deal_OrderBy =
   | 'pricePerWorkerEpoch'
   | 'providersAccessList'
   | 'providersAccessType'
+  | 'registeredWorkersCurrentCount'
   | 'targetWorkers'
   | 'withdrawalSum';
 
@@ -1617,13 +1648,16 @@ export type Effector_OrderBy =
 export type GraphNetwork = {
   __typename?: 'GraphNetwork';
   capacityCommitmentsTotal: Scalars['BigInt']['output'];
+  capacityContractAddress?: Maybe<Scalars['String']['output']>;
   capacityMaxFailedRatio?: Maybe<Scalars['Int']['output']>;
+  coreContractAddress?: Maybe<Scalars['String']['output']>;
   coreEpochDuration?: Maybe<Scalars['Int']['output']>;
   dealsTotal: Scalars['BigInt']['output'];
   effectorsTotal: Scalars['BigInt']['output'];
   /** ID is set to 1 */
   id: Scalars['ID']['output'];
   initTimestamp?: Maybe<Scalars['Int']['output']>;
+  marketContractAddress?: Maybe<Scalars['String']['output']>;
   minRequiredProofsPerEpoch?: Maybe<Scalars['Int']['output']>;
   offersTotal: Scalars['BigInt']['output'];
   proofsTotal: Scalars['BigInt']['output'];
@@ -1643,6 +1677,26 @@ export type GraphNetwork_Filter = {
   capacityCommitmentsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
   capacityCommitmentsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
   capacityCommitmentsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  capacityContractAddress?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_gt?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_gte?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityContractAddress_lt?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_lte?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_not?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_not_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityContractAddress_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityContractAddress_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   capacityMaxFailedRatio?: InputMaybe<Scalars['Int']['input']>;
   capacityMaxFailedRatio_gt?: InputMaybe<Scalars['Int']['input']>;
   capacityMaxFailedRatio_gte?: InputMaybe<Scalars['Int']['input']>;
@@ -1651,6 +1705,26 @@ export type GraphNetwork_Filter = {
   capacityMaxFailedRatio_lte?: InputMaybe<Scalars['Int']['input']>;
   capacityMaxFailedRatio_not?: InputMaybe<Scalars['Int']['input']>;
   capacityMaxFailedRatio_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  coreContractAddress?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_contains?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_ends_with?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_gt?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_gte?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  coreContractAddress_lt?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_lte?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_not?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_not_contains?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  coreContractAddress_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_starts_with?: InputMaybe<Scalars['String']['input']>;
+  coreContractAddress_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   coreEpochDuration?: InputMaybe<Scalars['Int']['input']>;
   coreEpochDuration_gt?: InputMaybe<Scalars['Int']['input']>;
   coreEpochDuration_gte?: InputMaybe<Scalars['Int']['input']>;
@@ -1691,6 +1765,26 @@ export type GraphNetwork_Filter = {
   initTimestamp_lte?: InputMaybe<Scalars['Int']['input']>;
   initTimestamp_not?: InputMaybe<Scalars['Int']['input']>;
   initTimestamp_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  marketContractAddress?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_contains?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_ends_with?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_gt?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_gte?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  marketContractAddress_lt?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_lte?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_not?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_not_contains?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  marketContractAddress_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_starts_with?: InputMaybe<Scalars['String']['input']>;
+  marketContractAddress_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   minRequiredProofsPerEpoch?: InputMaybe<Scalars['Int']['input']>;
   minRequiredProofsPerEpoch_gt?: InputMaybe<Scalars['Int']['input']>;
   minRequiredProofsPerEpoch_gte?: InputMaybe<Scalars['Int']['input']>;
@@ -1736,12 +1830,15 @@ export type GraphNetwork_Filter = {
 
 export type GraphNetwork_OrderBy =
   | 'capacityCommitmentsTotal'
+  | 'capacityContractAddress'
   | 'capacityMaxFailedRatio'
+  | 'coreContractAddress'
   | 'coreEpochDuration'
   | 'dealsTotal'
   | 'effectorsTotal'
   | 'id'
   | 'initTimestamp'
+  | 'marketContractAddress'
   | 'minRequiredProofsPerEpoch'
   | 'offersTotal'
   | 'proofsTotal'

--- a/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
@@ -1212,6 +1212,8 @@ export type DealToJoinedOfferPeer_OrderBy =
 
 export type DealToPeer = {
   __typename?: 'DealToPeer';
+  /** Helper field to understand number of connections. */
+  connections: Scalars['Int']['output'];
   deal: Deal;
   id: Scalars['ID']['output'];
   peer: Peer;
@@ -1221,6 +1223,14 @@ export type DealToPeer_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<DealToPeer_Filter>>>;
+  connections?: InputMaybe<Scalars['Int']['input']>;
+  connections_gt?: InputMaybe<Scalars['Int']['input']>;
+  connections_gte?: InputMaybe<Scalars['Int']['input']>;
+  connections_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  connections_lt?: InputMaybe<Scalars['Int']['input']>;
+  connections_lte?: InputMaybe<Scalars['Int']['input']>;
+  connections_not?: InputMaybe<Scalars['Int']['input']>;
+  connections_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   deal?: InputMaybe<Scalars['String']['input']>;
   deal_?: InputMaybe<Deal_Filter>;
   deal_contains?: InputMaybe<Scalars['String']['input']>;
@@ -1275,6 +1285,7 @@ export type DealToPeer_Filter = {
 };
 
 export type DealToPeer_OrderBy =
+  | 'connections'
   | 'deal'
   | 'deal__appCID'
   | 'deal__createdAt'

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
@@ -15,16 +15,16 @@ export type DealsQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type DealsQueryQuery = { __typename?: 'Query', deals: Array<{ __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null }>, graphNetworks: Array<{ __typename?: 'GraphNetwork', dealsTotal: any }> };
+export type DealsQueryQuery = { __typename?: 'Query', deals: Array<{ __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null }>, graphNetworks: Array<{ __typename?: 'GraphNetwork', dealsTotal: any }> };
 
 export type DealQueryQueryVariables = Types.Exact<{
   id: Types.Scalars['ID']['input'];
 }>;
 
 
-export type DealQueryQuery = { __typename?: 'Query', deal?: { __typename?: 'Deal', maxWorkersPerProvider: number, appCID: string, pricePerWorkerEpoch: any, id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null } | null };
+export type DealQueryQuery = { __typename?: 'Query', deal?: { __typename?: 'Deal', maxWorkersPerProvider: number, appCID: string, pricePerWorkerEpoch: any, id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null } | null };
 
-export type BasicDealFragment = { __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null };
+export type BasicDealFragment = { __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null };
 
 export type ComputeUnitBasicFragment = { __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } };
 
@@ -63,6 +63,8 @@ export const BasicDealFragmentDoc = gql`
   minWorkers
   targetWorkers
   owner
+  registeredWorkersCurrentCount
+  matchedWorkersCurrentCount
   paymentToken {
     id
     symbol

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
@@ -15,16 +15,16 @@ export type DealsQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type DealsQueryQuery = { __typename?: 'Query', deals: Array<{ __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null }>, graphNetworks: Array<{ __typename?: 'GraphNetwork', dealsTotal: any }> };
+export type DealsQueryQuery = { __typename?: 'Query', deals: Array<{ __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', provider: { __typename?: 'Provider', id: string } }> | null }>, graphNetworks: Array<{ __typename?: 'GraphNetwork', dealsTotal: any }> };
 
 export type DealQueryQueryVariables = Types.Exact<{
   id: Types.Scalars['ID']['input'];
 }>;
 
 
-export type DealQueryQuery = { __typename?: 'Query', deal?: { __typename?: 'Deal', maxWorkersPerProvider: number, appCID: string, pricePerWorkerEpoch: any, id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null } | null };
+export type DealQueryQuery = { __typename?: 'Query', deal?: { __typename?: 'Deal', maxWorkersPerProvider: number, appCID: string, pricePerWorkerEpoch: any, id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', provider: { __typename?: 'Provider', id: string } }> | null } | null };
 
-export type BasicDealFragment = { __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', id: string }> | null };
+export type BasicDealFragment = { __typename?: 'Deal', id: string, createdAt: any, minWorkers: number, targetWorkers: number, owner: string, registeredWorkersCurrentCount: number, matchedWorkersCurrentCount: number, providersAccessType: number, maxPaidEpoch?: any | null, depositedSum: any, withdrawalSum: any, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', provider: { __typename?: 'Provider', id: string } }> | null };
 
 export type ComputeUnitBasicFragment = { __typename?: 'ComputeUnit', id: string, workerId?: string | null, provider: { __typename?: 'Provider', id: string } };
 
@@ -80,7 +80,9 @@ export const BasicDealFragmentDoc = gql`
   }
   providersAccessType
   providersAccessList {
-    id
+    provider {
+      id
+    }
   }
   maxPaidEpoch
   depositedSum

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
@@ -53,7 +53,9 @@ fragment BasicDeal on Deal {
     }
     providersAccessType
     providersAccessList {
-      id
+      provider {
+        id
+      }
     }
     maxPaidEpoch
     depositedSum

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
@@ -36,6 +36,8 @@ fragment BasicDeal on Deal {
     minWorkers
     targetWorkers
     owner
+    registeredWorkersCurrentCount
+    matchedWorkersCurrentCount
     paymentToken {
       id
       symbol

--- a/ts-client/src/dealExplorerClient/serializers/schemes.ts
+++ b/ts-client/src/dealExplorerClient/serializers/schemes.ts
@@ -179,9 +179,8 @@ export function serializeDealsShort(
       DEFAULT_TOKEN_VALUE_ROUNDING,
       deal.paymentToken.decimals,
     ),
-    // TODO: add missed implementations.
-    registeredWorkers: 0,
-    matchedWorkers: 0,
+    registeredWorkers: deal.registeredWorkersCurrentCount,
+    matchedWorkers: deal.matchedWorkersCurrentCount,
   };
 }
 

--- a/ts-client/src/dealMatcherClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealMatcherClient/indexerClient/generated.types.ts
@@ -2,45 +2,36 @@
 //@ts-nocheck
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
-export type MakeEmpty<
-  T extends { [key: string]: unknown },
-  K extends keyof T,
-> = { [_ in K]?: never };
-export type Incremental<T> =
-  | T
-  | {
-      [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never;
-    };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  BigDecimal: { input: any; output: any };
-  BigInt: { input: string; output: string };
-  Bytes: { input: any; output: any };
-  Int8: { input: any; output: any };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  BigDecimal: { input: any; output: any; }
+  BigInt: { input: string; output: string; }
+  Bytes: { input: any; output: any; }
+  Int8: { input: any; output: any; }
 };
 
+export type Aggregation_Interval =
+  | 'day'
+  | 'hour';
+
 export type BlockChangedFilter = {
-  number_gte: Scalars["Int"]["input"];
+  number_gte: Scalars['Int']['input'];
 };
 
 export type Block_Height = {
-  hash?: InputMaybe<Scalars["Bytes"]["input"]>;
-  number?: InputMaybe<Scalars["Int"]["input"]>;
-  number_gte?: InputMaybe<Scalars["Int"]["input"]>;
+  hash?: InputMaybe<Scalars['Bytes']['input']>;
+  number?: InputMaybe<Scalars['Int']['input']>;
+  number_gte?: InputMaybe<Scalars['Int']['input']>;
 };
 
 /**
@@ -48,511 +39,1047 @@ export type Block_Height = {
  *
  */
 export type CapacityCommitment = {
-  __typename?: "CapacityCommitment";
-  activeUnitCount: Scalars["Int"]["output"];
-  collateralPerUnit: Scalars["BigInt"]["output"];
-  delegator: Scalars["String"]["output"];
+  __typename?: 'CapacityCommitment';
+  activeUnitCount: Scalars['Int']['output'];
+  collateralPerUnit: Scalars['BigInt']['output'];
+  computeUnits?: Maybe<Array<CapacityCommitmentToComputeUnit>>;
+  computeUnitsCount: Scalars['Int']['output'];
+  /** timestamp of creation of CC. It does not mean that CC is started. */
+  createdAt: Scalars['BigInt']['output'];
+  delegator: Scalars['String']['output'];
   /** If CC deleted before collateral deposited. */
-  deleted: Scalars["Boolean"]["output"];
-  duration: Scalars["BigInt"]["output"];
-  endEpoch: Scalars["BigInt"]["output"];
-  exitedUnitCount: Scalars["Int"]["output"];
-  failedEpoch: Scalars["BigInt"]["output"];
-  id: Scalars["ID"]["output"];
-  nextAdditionalActiveUnitCount: Scalars["Int"]["output"];
+  deleted: Scalars['Boolean']['output'];
+  duration: Scalars['BigInt']['output'];
+  endEpoch: Scalars['BigInt']['output'];
+  exitedUnitCount: Scalars['Int']['output'];
+  failedEpoch: Scalars['BigInt']['output'];
+  id: Scalars['ID']['output'];
+  nextAdditionalActiveUnitCount: Scalars['Int']['output'];
   /** Calculated in subgraph field: next failed epoch means the next epoch without proofs submitted when CC declared to be Failed. */
-  nextCCFailedEpoch: Scalars["BigInt"]["output"];
+  nextCCFailedEpoch: Scalars['BigInt']['output'];
   peer: Peer;
-  rewardDelegatorRate: Scalars["Int"]["output"];
-  snapshotEpoch: Scalars["BigInt"]["output"];
-  startEpoch: Scalars["BigInt"]["output"];
+  provider: Provider;
+  rewardDelegatorRate: Scalars['Int']['output'];
+  rewardWithdrawn: Scalars['BigInt']['output'];
+  snapshotEpoch: Scalars['BigInt']['output'];
+  startEpoch: Scalars['BigInt']['output'];
   /** This status represents last stored status on chain (status that does not depends on the current epoch some how). */
   status?: Maybe<CapacityCommitmentStatus>;
-  totalCUFailCount: Scalars["Int"]["output"];
-  unitCount: Scalars["Int"]["output"];
+  submittedProofs?: Maybe<Array<SubmittedProof>>;
+  submittedProofsCount: Scalars['Int']['output'];
+  totalCUFailCount: Scalars['Int']['output'];
+  /** Collateral of native token (FLT) that has been deposited. */
+  totalCollateral: Scalars['BigInt']['output'];
 };
 
+
+/**
+ * To represent that Peer has capacity commitment for some time.
+ *
+ */
+export type CapacityCommitmentComputeUnitsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<CapacityCommitmentToComputeUnit_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<CapacityCommitmentToComputeUnit_Filter>;
+};
+
+
+/**
+ * To represent that Peer has capacity commitment for some time.
+ *
+ */
+export type CapacityCommitmentSubmittedProofsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<SubmittedProof_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<SubmittedProof_Filter>;
+};
+
+/** To represent statistics per epoch. This entity represent evaluation of CommitmentStatsUpdated events during time (epoch). */
+export type CapacityCommitmentStatsPerEpoch = {
+  __typename?: 'CapacityCommitmentStatsPerEpoch';
+  activeUnitCount: Scalars['Int']['output'];
+  blockNumberEnd: Scalars['BigInt']['output'];
+  blockNumberStart: Scalars['BigInt']['output'];
+  capacityCommitment: CapacityCommitment;
+  /** Should be update after ComputeUnitPerEpochStat.submittedProofsCount reached min proofs border. */
+  computeUnitsWithMinRequiredProofsSubmittedCounter: Scalars['Int']['output'];
+  currentCCNextCCFailedEpoch: Scalars['BigInt']['output'];
+  epoch: Scalars['BigInt']['output'];
+  exitedUnitCount: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  nextAdditionalActiveUnitCount: Scalars['Int']['output'];
+  submittedProofs?: Maybe<Array<SubmittedProof>>;
+  submittedProofsCount: Scalars['Int']['output'];
+  totalCUFailCount: Scalars['Int']['output'];
+};
+
+
+/** To represent statistics per epoch. This entity represent evaluation of CommitmentStatsUpdated events during time (epoch). */
+export type CapacityCommitmentStatsPerEpochSubmittedProofsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<SubmittedProof_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<SubmittedProof_Filter>;
+};
+
+export type CapacityCommitmentStatsPerEpoch_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  activeUnitCount?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  activeUnitCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  and?: InputMaybe<Array<InputMaybe<CapacityCommitmentStatsPerEpoch_Filter>>>;
+  blockNumberEnd?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberEnd_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberEnd_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberEnd_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  blockNumberEnd_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberEnd_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberEnd_not?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberEnd_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  blockNumberStart?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberStart_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberStart_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberStart_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  blockNumberStart_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberStart_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberStart_not?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumberStart_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  capacityCommitment?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_?: InputMaybe<CapacityCommitment_Filter>;
+  capacityCommitment_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_lt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_lte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsWithMinRequiredProofsSubmittedCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  currentCCNextCCFailedEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  currentCCNextCCFailedEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  epoch?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  epoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  exitedUnitCount?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  exitedUnitCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  nextAdditionalActiveUnitCount?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextAdditionalActiveUnitCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<CapacityCommitmentStatsPerEpoch_Filter>>>;
+  submittedProofsCount?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  submittedProofsCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  submittedProofs_?: InputMaybe<SubmittedProof_Filter>;
+  totalCUFailCount?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  totalCUFailCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_not?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type CapacityCommitmentStatsPerEpoch_OrderBy =
+  | 'activeUnitCount'
+  | 'blockNumberEnd'
+  | 'blockNumberStart'
+  | 'capacityCommitment'
+  | 'capacityCommitment__activeUnitCount'
+  | 'capacityCommitment__collateralPerUnit'
+  | 'capacityCommitment__computeUnitsCount'
+  | 'capacityCommitment__createdAt'
+  | 'capacityCommitment__delegator'
+  | 'capacityCommitment__deleted'
+  | 'capacityCommitment__duration'
+  | 'capacityCommitment__endEpoch'
+  | 'capacityCommitment__exitedUnitCount'
+  | 'capacityCommitment__failedEpoch'
+  | 'capacityCommitment__id'
+  | 'capacityCommitment__nextAdditionalActiveUnitCount'
+  | 'capacityCommitment__nextCCFailedEpoch'
+  | 'capacityCommitment__rewardDelegatorRate'
+  | 'capacityCommitment__rewardWithdrawn'
+  | 'capacityCommitment__snapshotEpoch'
+  | 'capacityCommitment__startEpoch'
+  | 'capacityCommitment__status'
+  | 'capacityCommitment__submittedProofsCount'
+  | 'capacityCommitment__totalCUFailCount'
+  | 'capacityCommitment__totalCollateral'
+  | 'computeUnitsWithMinRequiredProofsSubmittedCounter'
+  | 'currentCCNextCCFailedEpoch'
+  | 'epoch'
+  | 'exitedUnitCount'
+  | 'id'
+  | 'nextAdditionalActiveUnitCount'
+  | 'submittedProofs'
+  | 'submittedProofsCount'
+  | 'totalCUFailCount';
+
 export type CapacityCommitmentStatus =
-  | "Active"
-  | "Failed"
-  | "Inactive"
-  | "Removed"
-  | "WaitDelegation"
-  | "WaitStart";
+  | 'Active'
+  | 'Failed'
+  | 'Inactive'
+  | 'Removed'
+  | 'WaitDelegation'
+  | 'WaitStart';
+
+export type CapacityCommitmentToComputeUnit = {
+  __typename?: 'CapacityCommitmentToComputeUnit';
+  capacityCommitment: CapacityCommitment;
+  computeUnit: ComputeUnit;
+  id: Scalars['ID']['output'];
+};
+
+export type CapacityCommitmentToComputeUnit_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<CapacityCommitmentToComputeUnit_Filter>>>;
+  capacityCommitment?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_?: InputMaybe<CapacityCommitment_Filter>;
+  capacityCommitment_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_lt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_lte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_?: InputMaybe<ComputeUnit_Filter>;
+  computeUnit_contains?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_ends_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_gt?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_gte?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  computeUnit_lt?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_lte?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_contains?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  computeUnit_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_starts_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<CapacityCommitmentToComputeUnit_Filter>>>;
+};
+
+export type CapacityCommitmentToComputeUnit_OrderBy =
+  | 'capacityCommitment'
+  | 'capacityCommitment__activeUnitCount'
+  | 'capacityCommitment__collateralPerUnit'
+  | 'capacityCommitment__computeUnitsCount'
+  | 'capacityCommitment__createdAt'
+  | 'capacityCommitment__delegator'
+  | 'capacityCommitment__deleted'
+  | 'capacityCommitment__duration'
+  | 'capacityCommitment__endEpoch'
+  | 'capacityCommitment__exitedUnitCount'
+  | 'capacityCommitment__failedEpoch'
+  | 'capacityCommitment__id'
+  | 'capacityCommitment__nextAdditionalActiveUnitCount'
+  | 'capacityCommitment__nextCCFailedEpoch'
+  | 'capacityCommitment__rewardDelegatorRate'
+  | 'capacityCommitment__rewardWithdrawn'
+  | 'capacityCommitment__snapshotEpoch'
+  | 'capacityCommitment__startEpoch'
+  | 'capacityCommitment__status'
+  | 'capacityCommitment__submittedProofsCount'
+  | 'capacityCommitment__totalCUFailCount'
+  | 'capacityCommitment__totalCollateral'
+  | 'computeUnit'
+  | 'computeUnit__createdAt'
+  | 'computeUnit__id'
+  | 'computeUnit__submittedProofsCount'
+  | 'computeUnit__workerId'
+  | 'id';
 
 export type CapacityCommitment_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
-  activeUnitCount?: InputMaybe<Scalars["Int"]["input"]>;
-  activeUnitCount_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  activeUnitCount_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  activeUnitCount_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  activeUnitCount_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  activeUnitCount_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  activeUnitCount_not?: InputMaybe<Scalars["Int"]["input"]>;
-  activeUnitCount_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
+  activeUnitCount?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  activeUnitCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
+  activeUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   and?: InputMaybe<Array<InputMaybe<CapacityCommitment_Filter>>>;
-  collateralPerUnit?: InputMaybe<Scalars["BigInt"]["input"]>;
-  collateralPerUnit_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  collateralPerUnit_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  collateralPerUnit_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  collateralPerUnit_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  collateralPerUnit_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  collateralPerUnit_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  collateralPerUnit_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  delegator?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_contains?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_gt?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_gte?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  delegator_lt?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_lte?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_not?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  delegator_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  delegator_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deleted?: InputMaybe<Scalars["Boolean"]["input"]>;
-  deleted_in?: InputMaybe<Array<Scalars["Boolean"]["input"]>>;
-  deleted_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  deleted_not_in?: InputMaybe<Array<Scalars["Boolean"]["input"]>>;
-  duration?: InputMaybe<Scalars["BigInt"]["input"]>;
-  duration_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  duration_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  duration_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  duration_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  duration_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  duration_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  duration_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  endEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  endEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  endEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  endEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  endEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  endEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  endEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  endEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  exitedUnitCount?: InputMaybe<Scalars["Int"]["input"]>;
-  exitedUnitCount_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  exitedUnitCount_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  exitedUnitCount_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  exitedUnitCount_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  exitedUnitCount_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  exitedUnitCount_not?: InputMaybe<Scalars["Int"]["input"]>;
-  exitedUnitCount_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  failedEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  failedEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  failedEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  failedEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  failedEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  failedEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  failedEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  failedEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  nextAdditionalActiveUnitCount?: InputMaybe<Scalars["Int"]["input"]>;
-  nextAdditionalActiveUnitCount_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  nextAdditionalActiveUnitCount_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  nextAdditionalActiveUnitCount_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  nextAdditionalActiveUnitCount_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  nextAdditionalActiveUnitCount_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  nextAdditionalActiveUnitCount_not?: InputMaybe<Scalars["Int"]["input"]>;
-  nextAdditionalActiveUnitCount_not_in?: InputMaybe<
-    Array<Scalars["Int"]["input"]>
-  >;
-  nextCCFailedEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  nextCCFailedEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  nextCCFailedEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  nextCCFailedEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  nextCCFailedEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  nextCCFailedEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  nextCCFailedEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  nextCCFailedEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  collateralPerUnit?: InputMaybe<Scalars['BigInt']['input']>;
+  collateralPerUnit_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  collateralPerUnit_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  collateralPerUnit_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  collateralPerUnit_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  collateralPerUnit_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  collateralPerUnit_not?: InputMaybe<Scalars['BigInt']['input']>;
+  collateralPerUnit_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  computeUnitsCount?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsCount_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnits_?: InputMaybe<CapacityCommitmentToComputeUnit_Filter>;
+  createdAt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  delegator?: InputMaybe<Scalars['String']['input']>;
+  delegator_contains?: InputMaybe<Scalars['String']['input']>;
+  delegator_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  delegator_ends_with?: InputMaybe<Scalars['String']['input']>;
+  delegator_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  delegator_gt?: InputMaybe<Scalars['String']['input']>;
+  delegator_gte?: InputMaybe<Scalars['String']['input']>;
+  delegator_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  delegator_lt?: InputMaybe<Scalars['String']['input']>;
+  delegator_lte?: InputMaybe<Scalars['String']['input']>;
+  delegator_not?: InputMaybe<Scalars['String']['input']>;
+  delegator_not_contains?: InputMaybe<Scalars['String']['input']>;
+  delegator_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  delegator_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  delegator_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  delegator_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  delegator_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  delegator_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  delegator_starts_with?: InputMaybe<Scalars['String']['input']>;
+  delegator_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  deleted_not?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  duration?: InputMaybe<Scalars['BigInt']['input']>;
+  duration_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  duration_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  duration_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  duration_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  duration_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  duration_not?: InputMaybe<Scalars['BigInt']['input']>;
+  duration_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  endEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  endEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  endEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  endEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  endEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  endEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  exitedUnitCount?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  exitedUnitCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
+  exitedUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  failedEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  failedEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  failedEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  failedEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  failedEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  failedEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  failedEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  failedEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  nextAdditionalActiveUnitCount?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextAdditionalActiveUnitCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
+  nextAdditionalActiveUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  nextCCFailedEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  nextCCFailedEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  nextCCFailedEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  nextCCFailedEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  nextCCFailedEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  nextCCFailedEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  nextCCFailedEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  nextCCFailedEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   or?: InputMaybe<Array<InputMaybe<CapacityCommitment_Filter>>>;
-  peer?: InputMaybe<Scalars["String"]["input"]>;
+  peer?: InputMaybe<Scalars['String']['input']>;
   peer_?: InputMaybe<Peer_Filter>;
-  peer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_lt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_lte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  rewardDelegatorRate?: InputMaybe<Scalars["Int"]["input"]>;
-  rewardDelegatorRate_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  rewardDelegatorRate_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  rewardDelegatorRate_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  rewardDelegatorRate_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  rewardDelegatorRate_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  rewardDelegatorRate_not?: InputMaybe<Scalars["Int"]["input"]>;
-  rewardDelegatorRate_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  snapshotEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  snapshotEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  snapshotEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  snapshotEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  snapshotEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  snapshotEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  snapshotEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  snapshotEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  startEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  startEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  startEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  startEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  startEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  startEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  startEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  startEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  peer_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_gt?: InputMaybe<Scalars['String']['input']>;
+  peer_gte?: InputMaybe<Scalars['String']['input']>;
+  peer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_lt?: InputMaybe<Scalars['String']['input']>;
+  peer_lte?: InputMaybe<Scalars['String']['input']>;
+  peer_not?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  provider_?: InputMaybe<Provider_Filter>;
+  provider_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_gt?: InputMaybe<Scalars['String']['input']>;
+  provider_gte?: InputMaybe<Scalars['String']['input']>;
+  provider_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_lt?: InputMaybe<Scalars['String']['input']>;
+  provider_lte?: InputMaybe<Scalars['String']['input']>;
+  provider_not?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  rewardDelegatorRate?: InputMaybe<Scalars['Int']['input']>;
+  rewardDelegatorRate_gt?: InputMaybe<Scalars['Int']['input']>;
+  rewardDelegatorRate_gte?: InputMaybe<Scalars['Int']['input']>;
+  rewardDelegatorRate_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  rewardDelegatorRate_lt?: InputMaybe<Scalars['Int']['input']>;
+  rewardDelegatorRate_lte?: InputMaybe<Scalars['Int']['input']>;
+  rewardDelegatorRate_not?: InputMaybe<Scalars['Int']['input']>;
+  rewardDelegatorRate_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  rewardWithdrawn?: InputMaybe<Scalars['BigInt']['input']>;
+  rewardWithdrawn_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  rewardWithdrawn_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  rewardWithdrawn_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  rewardWithdrawn_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  rewardWithdrawn_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  rewardWithdrawn_not?: InputMaybe<Scalars['BigInt']['input']>;
+  rewardWithdrawn_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  snapshotEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  snapshotEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  snapshotEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  snapshotEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  snapshotEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  snapshotEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  snapshotEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  snapshotEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  startEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  startEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  startEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  startEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  startEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  startEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   status?: InputMaybe<CapacityCommitmentStatus>;
   status_in?: InputMaybe<Array<CapacityCommitmentStatus>>;
   status_not?: InputMaybe<CapacityCommitmentStatus>;
   status_not_in?: InputMaybe<Array<CapacityCommitmentStatus>>;
-  totalCUFailCount?: InputMaybe<Scalars["Int"]["input"]>;
-  totalCUFailCount_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  totalCUFailCount_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  totalCUFailCount_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  totalCUFailCount_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  totalCUFailCount_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  totalCUFailCount_not?: InputMaybe<Scalars["Int"]["input"]>;
-  totalCUFailCount_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  unitCount?: InputMaybe<Scalars["Int"]["input"]>;
-  unitCount_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  unitCount_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  unitCount_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  unitCount_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  unitCount_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  unitCount_not?: InputMaybe<Scalars["Int"]["input"]>;
-  unitCount_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
+  submittedProofsCount?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  submittedProofsCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  submittedProofs_?: InputMaybe<SubmittedProof_Filter>;
+  totalCUFailCount?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  totalCUFailCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_not?: InputMaybe<Scalars['Int']['input']>;
+  totalCUFailCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  totalCollateral?: InputMaybe<Scalars['BigInt']['input']>;
+  totalCollateral_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  totalCollateral_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  totalCollateral_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  totalCollateral_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  totalCollateral_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  totalCollateral_not?: InputMaybe<Scalars['BigInt']['input']>;
+  totalCollateral_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
 };
 
 export type CapacityCommitment_OrderBy =
-  | "activeUnitCount"
-  | "collateralPerUnit"
-  | "delegator"
-  | "deleted"
-  | "duration"
-  | "endEpoch"
-  | "exitedUnitCount"
-  | "failedEpoch"
-  | "id"
-  | "nextAdditionalActiveUnitCount"
-  | "nextCCFailedEpoch"
-  | "peer"
-  | "peer__currentCCCollateralDepositedAt"
-  | "peer__currentCCEndEpoch"
-  | "peer__currentCCNextCCFailedEpoch"
-  | "peer__id"
-  | "peer__isAnyJoinedDeals"
-  | "rewardDelegatorRate"
-  | "snapshotEpoch"
-  | "startEpoch"
-  | "status"
-  | "totalCUFailCount"
-  | "unitCount";
+  | 'activeUnitCount'
+  | 'collateralPerUnit'
+  | 'computeUnits'
+  | 'computeUnitsCount'
+  | 'createdAt'
+  | 'delegator'
+  | 'deleted'
+  | 'duration'
+  | 'endEpoch'
+  | 'exitedUnitCount'
+  | 'failedEpoch'
+  | 'id'
+  | 'nextAdditionalActiveUnitCount'
+  | 'nextCCFailedEpoch'
+  | 'peer'
+  | 'peer__computeUnitsInCapacityCommitment'
+  | 'peer__computeUnitsInDeal'
+  | 'peer__computeUnitsTotal'
+  | 'peer__currentCCCollateralDepositedAt'
+  | 'peer__currentCCEndEpoch'
+  | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__id'
+  | 'peer__isAnyJoinedDeals'
+  | 'provider'
+  | 'provider__approved'
+  | 'provider__computeUnitsAvailable'
+  | 'provider__computeUnitsTotal'
+  | 'provider__createdAt'
+  | 'provider__id'
+  | 'provider__name'
+  | 'provider__peerCount'
+  | 'provider__registered'
+  | 'rewardDelegatorRate'
+  | 'rewardWithdrawn'
+  | 'snapshotEpoch'
+  | 'startEpoch'
+  | 'status'
+  | 'submittedProofs'
+  | 'submittedProofsCount'
+  | 'totalCUFailCount'
+  | 'totalCollateral';
 
 export type ComputeUnit = {
-  __typename?: "ComputeUnit";
+  __typename?: 'ComputeUnit';
+  createdAt: Scalars['BigInt']['output'];
   deal?: Maybe<Deal>;
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   peer: Peer;
   /** In order to simplify relation for query. */
   provider: Provider;
-  workerId?: Maybe<Scalars["String"]["output"]>;
+  submittedProofs?: Maybe<Array<SubmittedProof>>;
+  submittedProofsCount: Scalars['Int']['output'];
+  workerId?: Maybe<Scalars['String']['output']>;
 };
+
+
+export type ComputeUnitSubmittedProofsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<SubmittedProof_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<SubmittedProof_Filter>;
+};
+
+/** Helper stat model to count success proofs per epoch for a CU. */
+export type ComputeUnitPerEpochStat = {
+  __typename?: 'ComputeUnitPerEpochStat';
+  capacityCommitment?: Maybe<CapacityCommitment>;
+  computeUnit: ComputeUnit;
+  epoch: Scalars['BigInt']['output'];
+  id: Scalars['ID']['output'];
+  submittedProofsCount: Scalars['Int']['output'];
+};
+
+export type ComputeUnitPerEpochStat_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<ComputeUnitPerEpochStat_Filter>>>;
+  capacityCommitment?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_?: InputMaybe<CapacityCommitment_Filter>;
+  capacityCommitment_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_lt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_lte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_?: InputMaybe<ComputeUnit_Filter>;
+  computeUnit_contains?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_ends_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_gt?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_gte?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  computeUnit_lt?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_lte?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_contains?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  computeUnit_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_starts_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epoch?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  epoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  epoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<ComputeUnitPerEpochStat_Filter>>>;
+  submittedProofsCount?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  submittedProofsCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+};
+
+export type ComputeUnitPerEpochStat_OrderBy =
+  | 'capacityCommitment'
+  | 'capacityCommitment__activeUnitCount'
+  | 'capacityCommitment__collateralPerUnit'
+  | 'capacityCommitment__computeUnitsCount'
+  | 'capacityCommitment__createdAt'
+  | 'capacityCommitment__delegator'
+  | 'capacityCommitment__deleted'
+  | 'capacityCommitment__duration'
+  | 'capacityCommitment__endEpoch'
+  | 'capacityCommitment__exitedUnitCount'
+  | 'capacityCommitment__failedEpoch'
+  | 'capacityCommitment__id'
+  | 'capacityCommitment__nextAdditionalActiveUnitCount'
+  | 'capacityCommitment__nextCCFailedEpoch'
+  | 'capacityCommitment__rewardDelegatorRate'
+  | 'capacityCommitment__rewardWithdrawn'
+  | 'capacityCommitment__snapshotEpoch'
+  | 'capacityCommitment__startEpoch'
+  | 'capacityCommitment__status'
+  | 'capacityCommitment__submittedProofsCount'
+  | 'capacityCommitment__totalCUFailCount'
+  | 'capacityCommitment__totalCollateral'
+  | 'computeUnit'
+  | 'computeUnit__createdAt'
+  | 'computeUnit__id'
+  | 'computeUnit__submittedProofsCount'
+  | 'computeUnit__workerId'
+  | 'epoch'
+  | 'id'
+  | 'submittedProofsCount';
 
 export type ComputeUnit_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<ComputeUnit_Filter>>>;
-  deal?: InputMaybe<Scalars["String"]["input"]>;
+  createdAt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  deal?: InputMaybe<Scalars['String']['input']>;
   deal_?: InputMaybe<Deal_Filter>;
-  deal_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_lt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_lte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  deal_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_gt?: InputMaybe<Scalars['String']['input']>;
+  deal_gte?: InputMaybe<Scalars['String']['input']>;
+  deal_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_lt?: InputMaybe<Scalars['String']['input']>;
+  deal_lte?: InputMaybe<Scalars['String']['input']>;
+  deal_not?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   or?: InputMaybe<Array<InputMaybe<ComputeUnit_Filter>>>;
-  peer?: InputMaybe<Scalars["String"]["input"]>;
+  peer?: InputMaybe<Scalars['String']['input']>;
   peer_?: InputMaybe<Peer_Filter>;
-  peer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_lt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_lte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider?: InputMaybe<Scalars["String"]["input"]>;
+  peer_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_gt?: InputMaybe<Scalars['String']['input']>;
+  peer_gte?: InputMaybe<Scalars['String']['input']>;
+  peer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_lt?: InputMaybe<Scalars['String']['input']>;
+  peer_lte?: InputMaybe<Scalars['String']['input']>;
+  peer_not?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
   provider_?: InputMaybe<Provider_Filter>;
-  provider_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_lt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_lte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  workerId?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_contains?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_gt?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_gte?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  workerId_lt?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_lte?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_not?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  workerId_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  workerId_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  provider_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_gt?: InputMaybe<Scalars['String']['input']>;
+  provider_gte?: InputMaybe<Scalars['String']['input']>;
+  provider_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_lt?: InputMaybe<Scalars['String']['input']>;
+  provider_lte?: InputMaybe<Scalars['String']['input']>;
+  provider_not?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  submittedProofsCount?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  submittedProofsCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not?: InputMaybe<Scalars['Int']['input']>;
+  submittedProofsCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  submittedProofs_?: InputMaybe<SubmittedProof_Filter>;
+  workerId?: InputMaybe<Scalars['String']['input']>;
+  workerId_contains?: InputMaybe<Scalars['String']['input']>;
+  workerId_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  workerId_ends_with?: InputMaybe<Scalars['String']['input']>;
+  workerId_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  workerId_gt?: InputMaybe<Scalars['String']['input']>;
+  workerId_gte?: InputMaybe<Scalars['String']['input']>;
+  workerId_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  workerId_lt?: InputMaybe<Scalars['String']['input']>;
+  workerId_lte?: InputMaybe<Scalars['String']['input']>;
+  workerId_not?: InputMaybe<Scalars['String']['input']>;
+  workerId_not_contains?: InputMaybe<Scalars['String']['input']>;
+  workerId_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  workerId_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  workerId_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  workerId_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  workerId_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  workerId_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  workerId_starts_with?: InputMaybe<Scalars['String']['input']>;
+  workerId_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type ComputeUnit_OrderBy =
-  | "deal"
-  | "deal__appCID"
-  | "deal__createdAt"
-  | "deal__depositedSum"
-  | "deal__id"
-  | "deal__maxPaidEpoch"
-  | "deal__maxWorkersPerProvider"
-  | "deal__minWorkers"
-  | "deal__owner"
-  | "deal__pricePerWorkerEpoch"
-  | "deal__providersAccessType"
-  | "deal__targetWorkers"
-  | "deal__withdrawalSum"
-  | "id"
-  | "peer"
-  | "peer__currentCCCollateralDepositedAt"
-  | "peer__currentCCEndEpoch"
-  | "peer__currentCCNextCCFailedEpoch"
-  | "peer__id"
-  | "peer__isAnyJoinedDeals"
-  | "provider"
-  | "provider__approved"
-  | "provider__computeUnitsAvailable"
-  | "provider__computeUnitsTotal"
-  | "provider__createdAt"
-  | "provider__effectorCount"
-  | "provider__id"
-  | "provider__name"
-  | "provider__peerCount"
-  | "workerId";
+  | 'createdAt'
+  | 'deal'
+  | 'deal__appCID'
+  | 'deal__createdAt'
+  | 'deal__depositedSum'
+  | 'deal__id'
+  | 'deal__maxPaidEpoch'
+  | 'deal__maxWorkersPerProvider'
+  | 'deal__minWorkers'
+  | 'deal__owner'
+  | 'deal__pricePerWorkerEpoch'
+  | 'deal__providersAccessType'
+  | 'deal__targetWorkers'
+  | 'deal__withdrawalSum'
+  | 'id'
+  | 'peer'
+  | 'peer__computeUnitsInCapacityCommitment'
+  | 'peer__computeUnitsInDeal'
+  | 'peer__computeUnitsTotal'
+  | 'peer__currentCCCollateralDepositedAt'
+  | 'peer__currentCCEndEpoch'
+  | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__id'
+  | 'peer__isAnyJoinedDeals'
+  | 'provider'
+  | 'provider__approved'
+  | 'provider__computeUnitsAvailable'
+  | 'provider__computeUnitsTotal'
+  | 'provider__createdAt'
+  | 'provider__id'
+  | 'provider__name'
+  | 'provider__peerCount'
+  | 'provider__registered'
+  | 'submittedProofs'
+  | 'submittedProofsCount'
+  | 'workerId';
 
 export type Deal = {
-  __typename?: "Deal";
+  __typename?: 'Deal';
   /** I.e. Matching Result (Figma). */
   addedComputeUnits?: Maybe<Array<ComputeUnit>>;
-  appCID: Scalars["String"]["output"];
-  createdAt: Scalars["BigInt"]["output"];
-  depositedSum: Scalars["BigInt"]["output"];
+  appCID: Scalars['String']['output'];
+  createdAt: Scalars['BigInt']['output'];
+  depositedSum: Scalars['BigInt']['output'];
   effectors?: Maybe<Array<DealToEffector>>;
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   /** Many to many to access joined peers to maintain protocol restrictions */
   joinedPeers?: Maybe<Array<DealToPeer>>;
-  maxPaidEpoch?: Maybe<Scalars["BigInt"]["output"]>;
-  maxWorkersPerProvider: Scalars["Int"]["output"];
-  minWorkers: Scalars["Int"]["output"];
-  owner: Scalars["String"]["output"];
+  maxPaidEpoch?: Maybe<Scalars['BigInt']['output']>;
+  maxWorkersPerProvider: Scalars['Int']['output'];
+  minWorkers: Scalars['Int']['output'];
+  owner: Scalars['String']['output'];
   paymentToken: Token;
-  pricePerWorkerEpoch: Scalars["BigInt"]["output"];
+  pricePerWorkerEpoch: Scalars['BigInt']['output'];
   providersAccessList?: Maybe<Array<DealToProvidersAccess>>;
   /** It represents AccessType of Deal contract. */
-  providersAccessType: Scalars["Int"]["output"];
-  targetWorkers: Scalars["Int"]["output"];
-  withdrawalSum: Scalars["BigInt"]["output"];
+  providersAccessType: Scalars['Int']['output'];
+  targetWorkers: Scalars['Int']['output'];
+  withdrawalSum: Scalars['BigInt']['output'];
 };
 
+
 export type DealAddedComputeUnitsArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<ComputeUnit_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ComputeUnit_Filter>;
 };
 
+
 export type DealEffectorsArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToEffector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<DealToEffector_Filter>;
 };
 
+
 export type DealJoinedPeersArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToPeer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<DealToPeer_Filter>;
 };
 
+
 export type DealProvidersAccessListArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToProvidersAccess_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<DealToProvidersAccess_Filter>;
 };
 
 export type DealToEffector = {
-  __typename?: "DealToEffector";
+  __typename?: 'DealToEffector';
   deal: Deal;
   effector: Effector;
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
 };
 
 export type DealToEffector_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<DealToEffector_Filter>>>;
-  deal?: InputMaybe<Scalars["String"]["input"]>;
+  deal?: InputMaybe<Scalars['String']['input']>;
   deal_?: InputMaybe<Deal_Filter>;
-  deal_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_lt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_lte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector?: InputMaybe<Scalars["String"]["input"]>;
+  deal_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_gt?: InputMaybe<Scalars['String']['input']>;
+  deal_gte?: InputMaybe<Scalars['String']['input']>;
+  deal_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_lt?: InputMaybe<Scalars['String']['input']>;
+  deal_lte?: InputMaybe<Scalars['String']['input']>;
+  deal_not?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector?: InputMaybe<Scalars['String']['input']>;
   effector_?: InputMaybe<Effector_Filter>;
-  effector_contains?: InputMaybe<Scalars["String"]["input"]>;
-  effector_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_gt?: InputMaybe<Scalars["String"]["input"]>;
-  effector_gte?: InputMaybe<Scalars["String"]["input"]>;
-  effector_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  effector_lt?: InputMaybe<Scalars["String"]["input"]>;
-  effector_lte?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  effector_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  effector_contains?: InputMaybe<Scalars['String']['input']>;
+  effector_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_ends_with?: InputMaybe<Scalars['String']['input']>;
+  effector_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_gt?: InputMaybe<Scalars['String']['input']>;
+  effector_gte?: InputMaybe<Scalars['String']['input']>;
+  effector_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  effector_lt?: InputMaybe<Scalars['String']['input']>;
+  effector_lte?: InputMaybe<Scalars['String']['input']>;
+  effector_not?: InputMaybe<Scalars['String']['input']>;
+  effector_not_contains?: InputMaybe<Scalars['String']['input']>;
+  effector_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  effector_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  effector_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  effector_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_starts_with?: InputMaybe<Scalars['String']['input']>;
+  effector_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   or?: InputMaybe<Array<InputMaybe<DealToEffector_Filter>>>;
 };
 
 export type DealToEffector_OrderBy =
-  | "deal"
-  | "deal__appCID"
-  | "deal__createdAt"
-  | "deal__depositedSum"
-  | "deal__id"
-  | "deal__maxPaidEpoch"
-  | "deal__maxWorkersPerProvider"
-  | "deal__minWorkers"
-  | "deal__owner"
-  | "deal__pricePerWorkerEpoch"
-  | "deal__providersAccessType"
-  | "deal__targetWorkers"
-  | "deal__withdrawalSum"
-  | "effector"
-  | "effector__description"
-  | "effector__id"
-  | "id";
+  | 'deal'
+  | 'deal__appCID'
+  | 'deal__createdAt'
+  | 'deal__depositedSum'
+  | 'deal__id'
+  | 'deal__maxPaidEpoch'
+  | 'deal__maxWorkersPerProvider'
+  | 'deal__minWorkers'
+  | 'deal__owner'
+  | 'deal__pricePerWorkerEpoch'
+  | 'deal__providersAccessType'
+  | 'deal__targetWorkers'
+  | 'deal__withdrawalSum'
+  | 'effector'
+  | 'effector__description'
+  | 'effector__id'
+  | 'id';
 
 /**
  * TODO: deprecate.
@@ -561,9 +1088,9 @@ export type DealToEffector_OrderBy =
  *
  */
 export type DealToJoinedOfferPeer = {
-  __typename?: "DealToJoinedOfferPeer";
+  __typename?: 'DealToJoinedOfferPeer';
   deal: Deal;
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   offer: Offer;
   peer: Peer;
 };
@@ -572,113 +1099,116 @@ export type DealToJoinedOfferPeer_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<DealToJoinedOfferPeer_Filter>>>;
-  deal?: InputMaybe<Scalars["String"]["input"]>;
+  deal?: InputMaybe<Scalars['String']['input']>;
   deal_?: InputMaybe<Deal_Filter>;
-  deal_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_lt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_lte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  offer?: InputMaybe<Scalars["String"]["input"]>;
+  deal_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_gt?: InputMaybe<Scalars['String']['input']>;
+  deal_gte?: InputMaybe<Scalars['String']['input']>;
+  deal_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_lt?: InputMaybe<Scalars['String']['input']>;
+  deal_lte?: InputMaybe<Scalars['String']['input']>;
+  deal_not?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  offer?: InputMaybe<Scalars['String']['input']>;
   offer_?: InputMaybe<Offer_Filter>;
-  offer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  offer_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_gt?: InputMaybe<Scalars["String"]["input"]>;
-  offer_gte?: InputMaybe<Scalars["String"]["input"]>;
-  offer_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  offer_lt?: InputMaybe<Scalars["String"]["input"]>;
-  offer_lte?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  offer_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  offer_contains?: InputMaybe<Scalars['String']['input']>;
+  offer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  offer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_gt?: InputMaybe<Scalars['String']['input']>;
+  offer_gte?: InputMaybe<Scalars['String']['input']>;
+  offer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  offer_lt?: InputMaybe<Scalars['String']['input']>;
+  offer_lte?: InputMaybe<Scalars['String']['input']>;
+  offer_not?: InputMaybe<Scalars['String']['input']>;
+  offer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  offer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  offer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  offer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  offer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  offer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   or?: InputMaybe<Array<InputMaybe<DealToJoinedOfferPeer_Filter>>>;
-  peer?: InputMaybe<Scalars["String"]["input"]>;
+  peer?: InputMaybe<Scalars['String']['input']>;
   peer_?: InputMaybe<Peer_Filter>;
-  peer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_lt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_lte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  peer_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_gt?: InputMaybe<Scalars['String']['input']>;
+  peer_gte?: InputMaybe<Scalars['String']['input']>;
+  peer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_lt?: InputMaybe<Scalars['String']['input']>;
+  peer_lte?: InputMaybe<Scalars['String']['input']>;
+  peer_not?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DealToJoinedOfferPeer_OrderBy =
-  | "deal"
-  | "deal__appCID"
-  | "deal__createdAt"
-  | "deal__depositedSum"
-  | "deal__id"
-  | "deal__maxPaidEpoch"
-  | "deal__maxWorkersPerProvider"
-  | "deal__minWorkers"
-  | "deal__owner"
-  | "deal__pricePerWorkerEpoch"
-  | "deal__providersAccessType"
-  | "deal__targetWorkers"
-  | "deal__withdrawalSum"
-  | "id"
-  | "offer"
-  | "offer__computeUnitsAvailable"
-  | "offer__computeUnitsTotal"
-  | "offer__createdAt"
-  | "offer__id"
-  | "offer__pricePerEpoch"
-  | "offer__updatedAt"
-  | "peer"
-  | "peer__currentCCCollateralDepositedAt"
-  | "peer__currentCCEndEpoch"
-  | "peer__currentCCNextCCFailedEpoch"
-  | "peer__id"
-  | "peer__isAnyJoinedDeals";
+  | 'deal'
+  | 'deal__appCID'
+  | 'deal__createdAt'
+  | 'deal__depositedSum'
+  | 'deal__id'
+  | 'deal__maxPaidEpoch'
+  | 'deal__maxWorkersPerProvider'
+  | 'deal__minWorkers'
+  | 'deal__owner'
+  | 'deal__pricePerWorkerEpoch'
+  | 'deal__providersAccessType'
+  | 'deal__targetWorkers'
+  | 'deal__withdrawalSum'
+  | 'id'
+  | 'offer'
+  | 'offer__computeUnitsAvailable'
+  | 'offer__computeUnitsTotal'
+  | 'offer__createdAt'
+  | 'offer__id'
+  | 'offer__pricePerEpoch'
+  | 'offer__updatedAt'
+  | 'peer'
+  | 'peer__computeUnitsInCapacityCommitment'
+  | 'peer__computeUnitsInDeal'
+  | 'peer__computeUnitsTotal'
+  | 'peer__currentCCCollateralDepositedAt'
+  | 'peer__currentCCEndEpoch'
+  | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__id'
+  | 'peer__isAnyJoinedDeals';
 
 export type DealToPeer = {
-  __typename?: "DealToPeer";
+  __typename?: 'DealToPeer';
   deal: Deal;
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   peer: Peer;
 };
 
@@ -686,86 +1216,89 @@ export type DealToPeer_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<DealToPeer_Filter>>>;
-  deal?: InputMaybe<Scalars["String"]["input"]>;
+  deal?: InputMaybe<Scalars['String']['input']>;
   deal_?: InputMaybe<Deal_Filter>;
-  deal_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_lt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_lte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  deal_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_gt?: InputMaybe<Scalars['String']['input']>;
+  deal_gte?: InputMaybe<Scalars['String']['input']>;
+  deal_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_lt?: InputMaybe<Scalars['String']['input']>;
+  deal_lte?: InputMaybe<Scalars['String']['input']>;
+  deal_not?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   or?: InputMaybe<Array<InputMaybe<DealToPeer_Filter>>>;
-  peer?: InputMaybe<Scalars["String"]["input"]>;
+  peer?: InputMaybe<Scalars['String']['input']>;
   peer_?: InputMaybe<Peer_Filter>;
-  peer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_gte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_lt?: InputMaybe<Scalars["String"]["input"]>;
-  peer_lte?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  peer_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  peer_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  peer_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_gt?: InputMaybe<Scalars['String']['input']>;
+  peer_gte?: InputMaybe<Scalars['String']['input']>;
+  peer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_lt?: InputMaybe<Scalars['String']['input']>;
+  peer_lte?: InputMaybe<Scalars['String']['input']>;
+  peer_not?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DealToPeer_OrderBy =
-  | "deal"
-  | "deal__appCID"
-  | "deal__createdAt"
-  | "deal__depositedSum"
-  | "deal__id"
-  | "deal__maxPaidEpoch"
-  | "deal__maxWorkersPerProvider"
-  | "deal__minWorkers"
-  | "deal__owner"
-  | "deal__pricePerWorkerEpoch"
-  | "deal__providersAccessType"
-  | "deal__targetWorkers"
-  | "deal__withdrawalSum"
-  | "id"
-  | "peer"
-  | "peer__currentCCCollateralDepositedAt"
-  | "peer__currentCCEndEpoch"
-  | "peer__currentCCNextCCFailedEpoch"
-  | "peer__id"
-  | "peer__isAnyJoinedDeals";
+  | 'deal'
+  | 'deal__appCID'
+  | 'deal__createdAt'
+  | 'deal__depositedSum'
+  | 'deal__id'
+  | 'deal__maxPaidEpoch'
+  | 'deal__maxWorkersPerProvider'
+  | 'deal__minWorkers'
+  | 'deal__owner'
+  | 'deal__pricePerWorkerEpoch'
+  | 'deal__providersAccessType'
+  | 'deal__targetWorkers'
+  | 'deal__withdrawalSum'
+  | 'id'
+  | 'peer'
+  | 'peer__computeUnitsInCapacityCommitment'
+  | 'peer__computeUnitsInDeal'
+  | 'peer__computeUnitsTotal'
+  | 'peer__currentCCCollateralDepositedAt'
+  | 'peer__currentCCEndEpoch'
+  | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__id'
+  | 'peer__isAnyJoinedDeals';
 
 /** It represents m2m b/w deal and provider in context of access list. */
 export type DealToProvidersAccess = {
-  __typename?: "DealToProvidersAccess";
+  __typename?: 'DealToProvidersAccess';
   deal: Deal;
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   provider: Provider;
 };
 
@@ -773,273 +1306,274 @@ export type DealToProvidersAccess_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<DealToProvidersAccess_Filter>>>;
-  deal?: InputMaybe<Scalars["String"]["input"]>;
+  deal?: InputMaybe<Scalars['String']['input']>;
   deal_?: InputMaybe<Deal_Filter>;
-  deal_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_gte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_lt?: InputMaybe<Scalars["String"]["input"]>;
-  deal_lte?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  deal_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  deal_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  deal_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_gt?: InputMaybe<Scalars['String']['input']>;
+  deal_gte?: InputMaybe<Scalars['String']['input']>;
+  deal_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_lt?: InputMaybe<Scalars['String']['input']>;
+  deal_lte?: InputMaybe<Scalars['String']['input']>;
+  deal_not?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains?: InputMaybe<Scalars['String']['input']>;
+  deal_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  deal_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with?: InputMaybe<Scalars['String']['input']>;
+  deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   or?: InputMaybe<Array<InputMaybe<DealToProvidersAccess_Filter>>>;
-  provider?: InputMaybe<Scalars["String"]["input"]>;
+  provider?: InputMaybe<Scalars['String']['input']>;
   provider_?: InputMaybe<Provider_Filter>;
-  provider_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_lt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_lte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  provider_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_gt?: InputMaybe<Scalars['String']['input']>;
+  provider_gte?: InputMaybe<Scalars['String']['input']>;
+  provider_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_lt?: InputMaybe<Scalars['String']['input']>;
+  provider_lte?: InputMaybe<Scalars['String']['input']>;
+  provider_not?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DealToProvidersAccess_OrderBy =
-  | "deal"
-  | "deal__appCID"
-  | "deal__createdAt"
-  | "deal__depositedSum"
-  | "deal__id"
-  | "deal__maxPaidEpoch"
-  | "deal__maxWorkersPerProvider"
-  | "deal__minWorkers"
-  | "deal__owner"
-  | "deal__pricePerWorkerEpoch"
-  | "deal__providersAccessType"
-  | "deal__targetWorkers"
-  | "deal__withdrawalSum"
-  | "id"
-  | "provider"
-  | "provider__approved"
-  | "provider__computeUnitsAvailable"
-  | "provider__computeUnitsTotal"
-  | "provider__createdAt"
-  | "provider__effectorCount"
-  | "provider__id"
-  | "provider__name"
-  | "provider__peerCount";
+  | 'deal'
+  | 'deal__appCID'
+  | 'deal__createdAt'
+  | 'deal__depositedSum'
+  | 'deal__id'
+  | 'deal__maxPaidEpoch'
+  | 'deal__maxWorkersPerProvider'
+  | 'deal__minWorkers'
+  | 'deal__owner'
+  | 'deal__pricePerWorkerEpoch'
+  | 'deal__providersAccessType'
+  | 'deal__targetWorkers'
+  | 'deal__withdrawalSum'
+  | 'id'
+  | 'provider'
+  | 'provider__approved'
+  | 'provider__computeUnitsAvailable'
+  | 'provider__computeUnitsTotal'
+  | 'provider__createdAt'
+  | 'provider__id'
+  | 'provider__name'
+  | 'provider__peerCount'
+  | 'provider__registered';
 
 export type Deal_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   addedComputeUnits_?: InputMaybe<ComputeUnit_Filter>;
   and?: InputMaybe<Array<InputMaybe<Deal_Filter>>>;
-  appCID?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_contains?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_gt?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_gte?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  appCID_lt?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_lte?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_not?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  appCID_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  appCID_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  createdAt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  createdAt_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  depositedSum?: InputMaybe<Scalars["BigInt"]["input"]>;
-  depositedSum_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  depositedSum_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  depositedSum_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  depositedSum_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  depositedSum_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  depositedSum_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  depositedSum_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  appCID?: InputMaybe<Scalars['String']['input']>;
+  appCID_contains?: InputMaybe<Scalars['String']['input']>;
+  appCID_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  appCID_ends_with?: InputMaybe<Scalars['String']['input']>;
+  appCID_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  appCID_gt?: InputMaybe<Scalars['String']['input']>;
+  appCID_gte?: InputMaybe<Scalars['String']['input']>;
+  appCID_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  appCID_lt?: InputMaybe<Scalars['String']['input']>;
+  appCID_lte?: InputMaybe<Scalars['String']['input']>;
+  appCID_not?: InputMaybe<Scalars['String']['input']>;
+  appCID_not_contains?: InputMaybe<Scalars['String']['input']>;
+  appCID_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  appCID_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  appCID_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  appCID_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  appCID_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  appCID_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  appCID_starts_with?: InputMaybe<Scalars['String']['input']>;
+  appCID_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  depositedSum?: InputMaybe<Scalars['BigInt']['input']>;
+  depositedSum_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  depositedSum_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  depositedSum_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  depositedSum_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  depositedSum_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  depositedSum_not?: InputMaybe<Scalars['BigInt']['input']>;
+  depositedSum_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   effectors_?: InputMaybe<DealToEffector_Filter>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   joinedPeers_?: InputMaybe<DealToPeer_Filter>;
-  maxPaidEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  maxPaidEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  maxPaidEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  maxPaidEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  maxPaidEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  maxPaidEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  maxPaidEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  maxPaidEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  maxWorkersPerProvider?: InputMaybe<Scalars["Int"]["input"]>;
-  maxWorkersPerProvider_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  maxWorkersPerProvider_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  maxWorkersPerProvider_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  maxWorkersPerProvider_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  maxWorkersPerProvider_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  maxWorkersPerProvider_not?: InputMaybe<Scalars["Int"]["input"]>;
-  maxWorkersPerProvider_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  minWorkers?: InputMaybe<Scalars["Int"]["input"]>;
-  minWorkers_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  minWorkers_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  minWorkers_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  minWorkers_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  minWorkers_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  minWorkers_not?: InputMaybe<Scalars["Int"]["input"]>;
-  minWorkers_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
+  maxPaidEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  maxPaidEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  maxPaidEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  maxPaidEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  maxPaidEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  maxPaidEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  maxPaidEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  maxPaidEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  maxWorkersPerProvider?: InputMaybe<Scalars['Int']['input']>;
+  maxWorkersPerProvider_gt?: InputMaybe<Scalars['Int']['input']>;
+  maxWorkersPerProvider_gte?: InputMaybe<Scalars['Int']['input']>;
+  maxWorkersPerProvider_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  maxWorkersPerProvider_lt?: InputMaybe<Scalars['Int']['input']>;
+  maxWorkersPerProvider_lte?: InputMaybe<Scalars['Int']['input']>;
+  maxWorkersPerProvider_not?: InputMaybe<Scalars['Int']['input']>;
+  maxWorkersPerProvider_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  minWorkers?: InputMaybe<Scalars['Int']['input']>;
+  minWorkers_gt?: InputMaybe<Scalars['Int']['input']>;
+  minWorkers_gte?: InputMaybe<Scalars['Int']['input']>;
+  minWorkers_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  minWorkers_lt?: InputMaybe<Scalars['Int']['input']>;
+  minWorkers_lte?: InputMaybe<Scalars['Int']['input']>;
+  minWorkers_not?: InputMaybe<Scalars['Int']['input']>;
+  minWorkers_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   or?: InputMaybe<Array<InputMaybe<Deal_Filter>>>;
-  owner?: InputMaybe<Scalars["String"]["input"]>;
-  owner_contains?: InputMaybe<Scalars["String"]["input"]>;
-  owner_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  owner_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  owner_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  owner_gt?: InputMaybe<Scalars["String"]["input"]>;
-  owner_gte?: InputMaybe<Scalars["String"]["input"]>;
-  owner_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  owner_lt?: InputMaybe<Scalars["String"]["input"]>;
-  owner_lte?: InputMaybe<Scalars["String"]["input"]>;
-  owner_not?: InputMaybe<Scalars["String"]["input"]>;
-  owner_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  owner_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  owner_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  owner_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  owner_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  owner_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  owner_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  owner_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  owner_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken?: InputMaybe<Scalars["String"]["input"]>;
+  owner?: InputMaybe<Scalars['String']['input']>;
+  owner_contains?: InputMaybe<Scalars['String']['input']>;
+  owner_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  owner_ends_with?: InputMaybe<Scalars['String']['input']>;
+  owner_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  owner_gt?: InputMaybe<Scalars['String']['input']>;
+  owner_gte?: InputMaybe<Scalars['String']['input']>;
+  owner_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  owner_lt?: InputMaybe<Scalars['String']['input']>;
+  owner_lte?: InputMaybe<Scalars['String']['input']>;
+  owner_not?: InputMaybe<Scalars['String']['input']>;
+  owner_not_contains?: InputMaybe<Scalars['String']['input']>;
+  owner_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  owner_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  owner_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  owner_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  owner_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  owner_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  owner_starts_with?: InputMaybe<Scalars['String']['input']>;
+  owner_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken?: InputMaybe<Scalars['String']['input']>;
   paymentToken_?: InputMaybe<Token_Filter>;
-  paymentToken_contains?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_gt?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_gte?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  paymentToken_lt?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_lte?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  paymentToken_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  pricePerWorkerEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerWorkerEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerWorkerEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerWorkerEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  pricePerWorkerEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerWorkerEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerWorkerEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerWorkerEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  paymentToken_contains?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_ends_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_gt?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_gte?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  paymentToken_lt?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_lte?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_contains?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  paymentToken_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_starts_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  pricePerWorkerEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerWorkerEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerWorkerEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerWorkerEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  pricePerWorkerEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerWorkerEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerWorkerEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerWorkerEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   providersAccessList_?: InputMaybe<DealToProvidersAccess_Filter>;
-  providersAccessType?: InputMaybe<Scalars["Int"]["input"]>;
-  providersAccessType_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  providersAccessType_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  providersAccessType_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  providersAccessType_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  providersAccessType_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  providersAccessType_not?: InputMaybe<Scalars["Int"]["input"]>;
-  providersAccessType_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  targetWorkers?: InputMaybe<Scalars["Int"]["input"]>;
-  targetWorkers_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  targetWorkers_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  targetWorkers_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  targetWorkers_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  targetWorkers_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  targetWorkers_not?: InputMaybe<Scalars["Int"]["input"]>;
-  targetWorkers_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  withdrawalSum?: InputMaybe<Scalars["BigInt"]["input"]>;
-  withdrawalSum_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  withdrawalSum_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  withdrawalSum_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  withdrawalSum_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  withdrawalSum_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  withdrawalSum_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  withdrawalSum_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  providersAccessType?: InputMaybe<Scalars['Int']['input']>;
+  providersAccessType_gt?: InputMaybe<Scalars['Int']['input']>;
+  providersAccessType_gte?: InputMaybe<Scalars['Int']['input']>;
+  providersAccessType_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  providersAccessType_lt?: InputMaybe<Scalars['Int']['input']>;
+  providersAccessType_lte?: InputMaybe<Scalars['Int']['input']>;
+  providersAccessType_not?: InputMaybe<Scalars['Int']['input']>;
+  providersAccessType_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  targetWorkers?: InputMaybe<Scalars['Int']['input']>;
+  targetWorkers_gt?: InputMaybe<Scalars['Int']['input']>;
+  targetWorkers_gte?: InputMaybe<Scalars['Int']['input']>;
+  targetWorkers_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  targetWorkers_lt?: InputMaybe<Scalars['Int']['input']>;
+  targetWorkers_lte?: InputMaybe<Scalars['Int']['input']>;
+  targetWorkers_not?: InputMaybe<Scalars['Int']['input']>;
+  targetWorkers_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  withdrawalSum?: InputMaybe<Scalars['BigInt']['input']>;
+  withdrawalSum_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  withdrawalSum_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  withdrawalSum_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  withdrawalSum_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  withdrawalSum_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  withdrawalSum_not?: InputMaybe<Scalars['BigInt']['input']>;
+  withdrawalSum_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
 };
 
 export type Deal_OrderBy =
-  | "addedComputeUnits"
-  | "appCID"
-  | "createdAt"
-  | "depositedSum"
-  | "effectors"
-  | "id"
-  | "joinedPeers"
-  | "maxPaidEpoch"
-  | "maxWorkersPerProvider"
-  | "minWorkers"
-  | "owner"
-  | "paymentToken"
-  | "paymentToken__decimals"
-  | "paymentToken__id"
-  | "paymentToken__symbol"
-  | "pricePerWorkerEpoch"
-  | "providersAccessList"
-  | "providersAccessType"
-  | "targetWorkers"
-  | "withdrawalSum";
+  | 'addedComputeUnits'
+  | 'appCID'
+  | 'createdAt'
+  | 'depositedSum'
+  | 'effectors'
+  | 'id'
+  | 'joinedPeers'
+  | 'maxPaidEpoch'
+  | 'maxWorkersPerProvider'
+  | 'minWorkers'
+  | 'owner'
+  | 'paymentToken'
+  | 'paymentToken__decimals'
+  | 'paymentToken__id'
+  | 'paymentToken__symbol'
+  | 'pricePerWorkerEpoch'
+  | 'providersAccessList'
+  | 'providersAccessType'
+  | 'targetWorkers'
+  | 'withdrawalSum';
 
 /** Effector table is obsolete table since it is a simple mapping. */
 export type Effector = {
-  __typename?: "Effector";
-  description: Scalars["String"]["output"];
+  __typename?: 'Effector';
+  description: Scalars['String']['output'];
   /** id and CID are the same. */
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   offers?: Maybe<Array<OfferToEffector>>;
 };
 
+
 /** Effector table is obsolete table since it is a simple mapping. */
 export type EffectorOffersArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<OfferToEffector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<OfferToEffector_Filter>;
 };
 
@@ -1047,149 +1581,182 @@ export type Effector_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Effector_Filter>>>;
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  description_contains?: InputMaybe<Scalars["String"]["input"]>;
-  description_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  description_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  description_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  description_gt?: InputMaybe<Scalars["String"]["input"]>;
-  description_gte?: InputMaybe<Scalars["String"]["input"]>;
-  description_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  description_lt?: InputMaybe<Scalars["String"]["input"]>;
-  description_lte?: InputMaybe<Scalars["String"]["input"]>;
-  description_not?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  description_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  description_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  description_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_gt?: InputMaybe<Scalars['String']['input']>;
+  description_gte?: InputMaybe<Scalars['String']['input']>;
+  description_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_lt?: InputMaybe<Scalars['String']['input']>;
+  description_lte?: InputMaybe<Scalars['String']['input']>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   offers_?: InputMaybe<OfferToEffector_Filter>;
   or?: InputMaybe<Array<InputMaybe<Effector_Filter>>>;
 };
 
-export type Effector_OrderBy = "description" | "id" | "offers";
+export type Effector_OrderBy =
+  | 'description'
+  | 'id'
+  | 'offers';
 
 export type GraphNetwork = {
-  __typename?: "GraphNetwork";
-  capacityMaxFailedRatio?: Maybe<Scalars["Int"]["output"]>;
-  coreEpochDuration?: Maybe<Scalars["Int"]["output"]>;
-  dealsTotal: Scalars["BigInt"]["output"];
-  effectorsTotal: Scalars["BigInt"]["output"];
+  __typename?: 'GraphNetwork';
+  capacityCommitmentsTotal: Scalars['BigInt']['output'];
+  capacityMaxFailedRatio?: Maybe<Scalars['Int']['output']>;
+  coreEpochDuration?: Maybe<Scalars['Int']['output']>;
+  dealsTotal: Scalars['BigInt']['output'];
+  effectorsTotal: Scalars['BigInt']['output'];
   /** ID is set to 1 */
-  id: Scalars["ID"]["output"];
-  initTimestamp?: Maybe<Scalars["Int"]["output"]>;
-  offersTotal: Scalars["BigInt"]["output"];
-  providersTotal: Scalars["BigInt"]["output"];
-  tokensTotal: Scalars["BigInt"]["output"];
+  id: Scalars['ID']['output'];
+  initTimestamp?: Maybe<Scalars['Int']['output']>;
+  minRequiredProofsPerEpoch?: Maybe<Scalars['Int']['output']>;
+  offersTotal: Scalars['BigInt']['output'];
+  proofsTotal: Scalars['BigInt']['output'];
+  providersTotal: Scalars['BigInt']['output'];
+  tokensTotal: Scalars['BigInt']['output'];
 };
 
 export type GraphNetwork_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<GraphNetwork_Filter>>>;
-  capacityMaxFailedRatio?: InputMaybe<Scalars["Int"]["input"]>;
-  capacityMaxFailedRatio_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  capacityMaxFailedRatio_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  capacityMaxFailedRatio_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  capacityMaxFailedRatio_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  capacityMaxFailedRatio_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  capacityMaxFailedRatio_not?: InputMaybe<Scalars["Int"]["input"]>;
-  capacityMaxFailedRatio_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  coreEpochDuration?: InputMaybe<Scalars["Int"]["input"]>;
-  coreEpochDuration_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  coreEpochDuration_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  coreEpochDuration_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  coreEpochDuration_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  coreEpochDuration_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  coreEpochDuration_not?: InputMaybe<Scalars["Int"]["input"]>;
-  coreEpochDuration_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  dealsTotal?: InputMaybe<Scalars["BigInt"]["input"]>;
-  dealsTotal_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  dealsTotal_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  dealsTotal_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  dealsTotal_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  dealsTotal_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  dealsTotal_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  dealsTotal_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  effectorsTotal?: InputMaybe<Scalars["BigInt"]["input"]>;
-  effectorsTotal_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  effectorsTotal_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  effectorsTotal_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  effectorsTotal_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  effectorsTotal_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  effectorsTotal_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  effectorsTotal_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  initTimestamp?: InputMaybe<Scalars["Int"]["input"]>;
-  initTimestamp_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  initTimestamp_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  initTimestamp_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  initTimestamp_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  initTimestamp_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  initTimestamp_not?: InputMaybe<Scalars["Int"]["input"]>;
-  initTimestamp_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  offersTotal?: InputMaybe<Scalars["BigInt"]["input"]>;
-  offersTotal_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  offersTotal_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  offersTotal_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  offersTotal_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  offersTotal_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  offersTotal_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  offersTotal_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  capacityCommitmentsTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  capacityCommitmentsTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  capacityCommitmentsTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  capacityCommitmentsTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  capacityCommitmentsTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  capacityCommitmentsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  capacityCommitmentsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  capacityCommitmentsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  capacityMaxFailedRatio?: InputMaybe<Scalars['Int']['input']>;
+  capacityMaxFailedRatio_gt?: InputMaybe<Scalars['Int']['input']>;
+  capacityMaxFailedRatio_gte?: InputMaybe<Scalars['Int']['input']>;
+  capacityMaxFailedRatio_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  capacityMaxFailedRatio_lt?: InputMaybe<Scalars['Int']['input']>;
+  capacityMaxFailedRatio_lte?: InputMaybe<Scalars['Int']['input']>;
+  capacityMaxFailedRatio_not?: InputMaybe<Scalars['Int']['input']>;
+  capacityMaxFailedRatio_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  coreEpochDuration?: InputMaybe<Scalars['Int']['input']>;
+  coreEpochDuration_gt?: InputMaybe<Scalars['Int']['input']>;
+  coreEpochDuration_gte?: InputMaybe<Scalars['Int']['input']>;
+  coreEpochDuration_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  coreEpochDuration_lt?: InputMaybe<Scalars['Int']['input']>;
+  coreEpochDuration_lte?: InputMaybe<Scalars['Int']['input']>;
+  coreEpochDuration_not?: InputMaybe<Scalars['Int']['input']>;
+  coreEpochDuration_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  dealsTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  dealsTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  dealsTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  dealsTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  dealsTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  dealsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  dealsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  dealsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  effectorsTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  effectorsTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  effectorsTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  effectorsTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  effectorsTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  effectorsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  effectorsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  effectorsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  initTimestamp?: InputMaybe<Scalars['Int']['input']>;
+  initTimestamp_gt?: InputMaybe<Scalars['Int']['input']>;
+  initTimestamp_gte?: InputMaybe<Scalars['Int']['input']>;
+  initTimestamp_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  initTimestamp_lt?: InputMaybe<Scalars['Int']['input']>;
+  initTimestamp_lte?: InputMaybe<Scalars['Int']['input']>;
+  initTimestamp_not?: InputMaybe<Scalars['Int']['input']>;
+  initTimestamp_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  minRequiredProofsPerEpoch?: InputMaybe<Scalars['Int']['input']>;
+  minRequiredProofsPerEpoch_gt?: InputMaybe<Scalars['Int']['input']>;
+  minRequiredProofsPerEpoch_gte?: InputMaybe<Scalars['Int']['input']>;
+  minRequiredProofsPerEpoch_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  minRequiredProofsPerEpoch_lt?: InputMaybe<Scalars['Int']['input']>;
+  minRequiredProofsPerEpoch_lte?: InputMaybe<Scalars['Int']['input']>;
+  minRequiredProofsPerEpoch_not?: InputMaybe<Scalars['Int']['input']>;
+  minRequiredProofsPerEpoch_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  offersTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  offersTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  offersTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  offersTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  offersTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  offersTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  offersTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  offersTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   or?: InputMaybe<Array<InputMaybe<GraphNetwork_Filter>>>;
-  providersTotal?: InputMaybe<Scalars["BigInt"]["input"]>;
-  providersTotal_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  providersTotal_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  providersTotal_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  providersTotal_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  providersTotal_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  providersTotal_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  providersTotal_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  tokensTotal?: InputMaybe<Scalars["BigInt"]["input"]>;
-  tokensTotal_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  tokensTotal_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  tokensTotal_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  tokensTotal_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  tokensTotal_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  tokensTotal_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  tokensTotal_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  proofsTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  proofsTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  proofsTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  proofsTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  proofsTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  proofsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  proofsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  proofsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  providersTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  providersTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  tokensTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  tokensTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  tokensTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  tokensTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  tokensTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  tokensTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  tokensTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  tokensTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
 };
 
 export type GraphNetwork_OrderBy =
-  | "capacityMaxFailedRatio"
-  | "coreEpochDuration"
-  | "dealsTotal"
-  | "effectorsTotal"
-  | "id"
-  | "initTimestamp"
-  | "offersTotal"
-  | "providersTotal"
-  | "tokensTotal";
+  | 'capacityCommitmentsTotal'
+  | 'capacityMaxFailedRatio'
+  | 'coreEpochDuration'
+  | 'dealsTotal'
+  | 'effectorsTotal'
+  | 'id'
+  | 'initTimestamp'
+  | 'minRequiredProofsPerEpoch'
+  | 'offersTotal'
+  | 'proofsTotal'
+  | 'providersTotal'
+  | 'tokensTotal';
 
 export type Offer = {
-  __typename?: "Offer";
-  computeUnitsAvailable?: Maybe<Scalars["Int"]["output"]>;
-  computeUnitsTotal?: Maybe<Scalars["Int"]["output"]>;
-  createdAt: Scalars["BigInt"]["output"];
+  __typename?: 'Offer';
+  computeUnitsAvailable?: Maybe<Scalars['Int']['output']>;
+  computeUnitsTotal?: Maybe<Scalars['Int']['output']>;
+  createdAt: Scalars['BigInt']['output'];
   effectors?: Maybe<Array<OfferToEffector>>;
   /**
    * Used in the next figma views:
@@ -1197,37 +1764,40 @@ export type Offer = {
    * - Offer 1.2
    *
    */
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   /** To support check that a peer already in a deal. */
   joinedOfferPeers?: Maybe<Array<DealToJoinedOfferPeer>>;
   paymentToken: Token;
   peers?: Maybe<Array<Peer>>;
-  pricePerEpoch: Scalars["BigInt"]["output"];
+  pricePerEpoch: Scalars['BigInt']['output'];
   provider: Provider;
-  updatedAt: Scalars["BigInt"]["output"];
+  updatedAt: Scalars['BigInt']['output'];
 };
 
+
 export type OfferEffectorsArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<OfferToEffector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<OfferToEffector_Filter>;
 };
 
+
 export type OfferJoinedOfferPeersArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToJoinedOfferPeer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<DealToJoinedOfferPeer_Filter>;
 };
 
+
 export type OfferPeersArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Peer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<Peer_Filter>;
 };
 
@@ -1246,9 +1816,9 @@ export type OfferPeersArgs = {
  *
  */
 export type OfferToEffector = {
-  __typename?: "OfferToEffector";
+  __typename?: 'OfferToEffector';
   effector: Effector;
-  id: Scalars["ID"]["output"];
+  id: Scalars['ID']['output'];
   offer: Offer;
 };
 
@@ -1256,238 +1826,248 @@ export type OfferToEffector_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<OfferToEffector_Filter>>>;
-  effector?: InputMaybe<Scalars["String"]["input"]>;
+  effector?: InputMaybe<Scalars['String']['input']>;
   effector_?: InputMaybe<Effector_Filter>;
-  effector_contains?: InputMaybe<Scalars["String"]["input"]>;
-  effector_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_gt?: InputMaybe<Scalars["String"]["input"]>;
-  effector_gte?: InputMaybe<Scalars["String"]["input"]>;
-  effector_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  effector_lt?: InputMaybe<Scalars["String"]["input"]>;
-  effector_lte?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  effector_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  effector_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  effector_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  offer?: InputMaybe<Scalars["String"]["input"]>;
+  effector_contains?: InputMaybe<Scalars['String']['input']>;
+  effector_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_ends_with?: InputMaybe<Scalars['String']['input']>;
+  effector_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_gt?: InputMaybe<Scalars['String']['input']>;
+  effector_gte?: InputMaybe<Scalars['String']['input']>;
+  effector_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  effector_lt?: InputMaybe<Scalars['String']['input']>;
+  effector_lte?: InputMaybe<Scalars['String']['input']>;
+  effector_not?: InputMaybe<Scalars['String']['input']>;
+  effector_not_contains?: InputMaybe<Scalars['String']['input']>;
+  effector_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  effector_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  effector_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  effector_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  effector_starts_with?: InputMaybe<Scalars['String']['input']>;
+  effector_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  offer?: InputMaybe<Scalars['String']['input']>;
   offer_?: InputMaybe<Offer_Filter>;
-  offer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  offer_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_gt?: InputMaybe<Scalars["String"]["input"]>;
-  offer_gte?: InputMaybe<Scalars["String"]["input"]>;
-  offer_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  offer_lt?: InputMaybe<Scalars["String"]["input"]>;
-  offer_lte?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  offer_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  offer_contains?: InputMaybe<Scalars['String']['input']>;
+  offer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  offer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_gt?: InputMaybe<Scalars['String']['input']>;
+  offer_gte?: InputMaybe<Scalars['String']['input']>;
+  offer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  offer_lt?: InputMaybe<Scalars['String']['input']>;
+  offer_lte?: InputMaybe<Scalars['String']['input']>;
+  offer_not?: InputMaybe<Scalars['String']['input']>;
+  offer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  offer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  offer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  offer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  offer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  offer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   or?: InputMaybe<Array<InputMaybe<OfferToEffector_Filter>>>;
 };
 
 export type OfferToEffector_OrderBy =
-  | "effector"
-  | "effector__description"
-  | "effector__id"
-  | "id"
-  | "offer"
-  | "offer__computeUnitsAvailable"
-  | "offer__computeUnitsTotal"
-  | "offer__createdAt"
-  | "offer__id"
-  | "offer__pricePerEpoch"
-  | "offer__updatedAt";
+  | 'effector'
+  | 'effector__description'
+  | 'effector__id'
+  | 'id'
+  | 'offer'
+  | 'offer__computeUnitsAvailable'
+  | 'offer__computeUnitsTotal'
+  | 'offer__createdAt'
+  | 'offer__id'
+  | 'offer__pricePerEpoch'
+  | 'offer__updatedAt';
 
 export type Offer_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Offer_Filter>>>;
-  computeUnitsAvailable?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  computeUnitsAvailable_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_not?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  computeUnitsTotal?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  computeUnitsTotal_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_not?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  createdAt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  createdAt_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  computeUnitsAvailable?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsAvailable_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsTotal?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsTotal_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  createdAt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   effectors_?: InputMaybe<OfferToEffector_Filter>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   joinedOfferPeers_?: InputMaybe<DealToJoinedOfferPeer_Filter>;
   or?: InputMaybe<Array<InputMaybe<Offer_Filter>>>;
-  paymentToken?: InputMaybe<Scalars["String"]["input"]>;
+  paymentToken?: InputMaybe<Scalars['String']['input']>;
   paymentToken_?: InputMaybe<Token_Filter>;
-  paymentToken_contains?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_gt?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_gte?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  paymentToken_lt?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_lte?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  paymentToken_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  paymentToken_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  paymentToken_contains?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_ends_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_gt?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_gte?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  paymentToken_lt?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_lte?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_contains?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  paymentToken_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_starts_with?: InputMaybe<Scalars['String']['input']>;
+  paymentToken_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   peers_?: InputMaybe<Peer_Filter>;
-  pricePerEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  pricePerEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  pricePerEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  provider?: InputMaybe<Scalars["String"]["input"]>;
+  pricePerEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  pricePerEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  pricePerEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  provider?: InputMaybe<Scalars['String']['input']>;
   provider_?: InputMaybe<Provider_Filter>;
-  provider_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_lt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_lte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  updatedAt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  updatedAt_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  updatedAt_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  updatedAt_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  updatedAt_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  updatedAt_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  updatedAt_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  updatedAt_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  provider_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_gt?: InputMaybe<Scalars['String']['input']>;
+  provider_gte?: InputMaybe<Scalars['String']['input']>;
+  provider_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_lt?: InputMaybe<Scalars['String']['input']>;
+  provider_lte?: InputMaybe<Scalars['String']['input']>;
+  provider_not?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  updatedAt?: InputMaybe<Scalars['BigInt']['input']>;
+  updatedAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  updatedAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  updatedAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  updatedAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  updatedAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  updatedAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  updatedAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
 };
 
 export type Offer_OrderBy =
-  | "computeUnitsAvailable"
-  | "computeUnitsTotal"
-  | "createdAt"
-  | "effectors"
-  | "id"
-  | "joinedOfferPeers"
-  | "paymentToken"
-  | "paymentToken__decimals"
-  | "paymentToken__id"
-  | "paymentToken__symbol"
-  | "peers"
-  | "pricePerEpoch"
-  | "provider"
-  | "provider__approved"
-  | "provider__computeUnitsAvailable"
-  | "provider__computeUnitsTotal"
-  | "provider__createdAt"
-  | "provider__effectorCount"
-  | "provider__id"
-  | "provider__name"
-  | "provider__peerCount"
-  | "updatedAt";
+  | 'computeUnitsAvailable'
+  | 'computeUnitsTotal'
+  | 'createdAt'
+  | 'effectors'
+  | 'id'
+  | 'joinedOfferPeers'
+  | 'paymentToken'
+  | 'paymentToken__decimals'
+  | 'paymentToken__id'
+  | 'paymentToken__symbol'
+  | 'peers'
+  | 'pricePerEpoch'
+  | 'provider'
+  | 'provider__approved'
+  | 'provider__computeUnitsAvailable'
+  | 'provider__computeUnitsTotal'
+  | 'provider__createdAt'
+  | 'provider__id'
+  | 'provider__name'
+  | 'provider__peerCount'
+  | 'provider__registered'
+  | 'updatedAt';
 
 /** Defines the order direction, either ascending or descending */
-export type OrderDirection = "asc" | "desc";
+export type OrderDirection =
+  | 'asc'
+  | 'desc';
 
 export type Peer = {
-  __typename?: "Peer";
+  __typename?: 'Peer';
   /** To access history of capacity commitments. */
   capacityCommitments?: Maybe<Array<CapacityCommitment>>;
   computeUnits?: Maybe<Array<ComputeUnit>>;
+  /** Compute units in any cc: update only when moved to CC or out: {UnitActivated, UnitDeactivated}. */
+  computeUnitsInCapacityCommitment: Scalars['Int']['output'];
+  /** Compute units in any deals: update only when moved to deal or out. */
+  computeUnitsInDeal: Scalars['Int']['output'];
+  computeUnitsTotal: Scalars['Int']['output'];
   /** To understand if collateral for peer have been submitted. This field should be use in conjunction with currentCapacityCommitment. */
-  currentCCCollateralDepositedAt?: Maybe<Scalars["BigInt"]["output"]>;
-  currentCCEndEpoch?: Maybe<Scalars["BigInt"]["output"]>;
-  currentCCNextCCFailedEpoch?: Maybe<Scalars["BigInt"]["output"]>;
+  currentCCCollateralDepositedAt?: Maybe<Scalars['BigInt']['output']>;
+  currentCCEndEpoch?: Maybe<Scalars['BigInt']['output']>;
+  currentCCNextCCFailedEpoch?: Maybe<Scalars['BigInt']['output']>;
   currentCapacityCommitment?: Maybe<CapacityCommitment>;
   /** ref to peerId in contract. */
-  id: Scalars["ID"]["output"];
-  isAnyJoinedDeals: Scalars["Boolean"]["output"];
+  id: Scalars['ID']['output'];
+  isAnyJoinedDeals: Scalars['Boolean']['output'];
   joinedDeals?: Maybe<Array<DealToPeer>>;
   offer: Offer;
   provider: Provider;
 };
 
+
 export type PeerCapacityCommitmentsArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<CapacityCommitment_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<CapacityCommitment_Filter>;
 };
 
+
 export type PeerComputeUnitsArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<ComputeUnit_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<ComputeUnit_Filter>;
 };
 
+
 export type PeerJoinedDealsArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToPeer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<DealToPeer_Filter>;
 };
 
@@ -1496,200 +2076,205 @@ export type Peer_Filter = {
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Peer_Filter>>>;
   capacityCommitments_?: InputMaybe<CapacityCommitment_Filter>;
+  computeUnitsInCapacityCommitment?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInCapacityCommitment_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInCapacityCommitment_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInCapacityCommitment_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsInCapacityCommitment_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInCapacityCommitment_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInCapacityCommitment_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInCapacityCommitment_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsInDeal?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInDeal_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInDeal_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInDeal_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsInDeal_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInDeal_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInDeal_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsInDeal_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsTotal?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsTotal_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   computeUnits_?: InputMaybe<ComputeUnit_Filter>;
-  currentCCCollateralDepositedAt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCCollateralDepositedAt_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCCollateralDepositedAt_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCCollateralDepositedAt_in?: InputMaybe<
-    Array<Scalars["BigInt"]["input"]>
-  >;
-  currentCCCollateralDepositedAt_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCCollateralDepositedAt_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCCollateralDepositedAt_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCCollateralDepositedAt_not_in?: InputMaybe<
-    Array<Scalars["BigInt"]["input"]>
-  >;
-  currentCCEndEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCEndEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCEndEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCEndEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  currentCCEndEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCEndEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCEndEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCEndEpoch_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  currentCCNextCCFailedEpoch?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCNextCCFailedEpoch_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCNextCCFailedEpoch_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCNextCCFailedEpoch_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  currentCCNextCCFailedEpoch_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCNextCCFailedEpoch_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCNextCCFailedEpoch_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  currentCCNextCCFailedEpoch_not_in?: InputMaybe<
-    Array<Scalars["BigInt"]["input"]>
-  >;
-  currentCapacityCommitment?: InputMaybe<Scalars["String"]["input"]>;
+  currentCCCollateralDepositedAt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCCollateralDepositedAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCCollateralDepositedAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCCollateralDepositedAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  currentCCCollateralDepositedAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCCollateralDepositedAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCCollateralDepositedAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCCollateralDepositedAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  currentCCEndEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCEndEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCEndEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCEndEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  currentCCEndEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCEndEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCEndEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCEndEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  currentCCNextCCFailedEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  currentCCNextCCFailedEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  currentCCNextCCFailedEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  currentCapacityCommitment?: InputMaybe<Scalars['String']['input']>;
   currentCapacityCommitment_?: InputMaybe<CapacityCommitment_Filter>;
-  currentCapacityCommitment_contains?: InputMaybe<Scalars["String"]["input"]>;
-  currentCapacityCommitment_contains_nocase?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  currentCapacityCommitment_ends_with_nocase?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_gt?: InputMaybe<Scalars["String"]["input"]>;
-  currentCapacityCommitment_gte?: InputMaybe<Scalars["String"]["input"]>;
-  currentCapacityCommitment_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  currentCapacityCommitment_lt?: InputMaybe<Scalars["String"]["input"]>;
-  currentCapacityCommitment_lte?: InputMaybe<Scalars["String"]["input"]>;
-  currentCapacityCommitment_not?: InputMaybe<Scalars["String"]["input"]>;
-  currentCapacityCommitment_not_contains?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_not_contains_nocase?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_not_ends_with?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_not_ends_with_nocase?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_not_in?: InputMaybe<
-    Array<Scalars["String"]["input"]>
-  >;
-  currentCapacityCommitment_not_starts_with?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_not_starts_with_nocase?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_starts_with?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  currentCapacityCommitment_starts_with_nocase?: InputMaybe<
-    Scalars["String"]["input"]
-  >;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  isAnyJoinedDeals?: InputMaybe<Scalars["Boolean"]["input"]>;
-  isAnyJoinedDeals_in?: InputMaybe<Array<Scalars["Boolean"]["input"]>>;
-  isAnyJoinedDeals_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  isAnyJoinedDeals_not_in?: InputMaybe<Array<Scalars["Boolean"]["input"]>>;
+  currentCapacityCommitment_contains?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_ends_with?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_gt?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_gte?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  currentCapacityCommitment_lt?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_lte?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_not?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_not_contains?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  currentCapacityCommitment_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
+  currentCapacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  isAnyJoinedDeals?: InputMaybe<Scalars['Boolean']['input']>;
+  isAnyJoinedDeals_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  isAnyJoinedDeals_not?: InputMaybe<Scalars['Boolean']['input']>;
+  isAnyJoinedDeals_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   joinedDeals_?: InputMaybe<DealToPeer_Filter>;
-  offer?: InputMaybe<Scalars["String"]["input"]>;
+  offer?: InputMaybe<Scalars['String']['input']>;
   offer_?: InputMaybe<Offer_Filter>;
-  offer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  offer_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_gt?: InputMaybe<Scalars["String"]["input"]>;
-  offer_gte?: InputMaybe<Scalars["String"]["input"]>;
-  offer_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  offer_lt?: InputMaybe<Scalars["String"]["input"]>;
-  offer_lte?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  offer_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  offer_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  offer_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  offer_contains?: InputMaybe<Scalars['String']['input']>;
+  offer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  offer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_gt?: InputMaybe<Scalars['String']['input']>;
+  offer_gte?: InputMaybe<Scalars['String']['input']>;
+  offer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  offer_lt?: InputMaybe<Scalars['String']['input']>;
+  offer_lte?: InputMaybe<Scalars['String']['input']>;
+  offer_not?: InputMaybe<Scalars['String']['input']>;
+  offer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  offer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  offer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  offer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  offer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  offer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  offer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   or?: InputMaybe<Array<InputMaybe<Peer_Filter>>>;
-  provider?: InputMaybe<Scalars["String"]["input"]>;
+  provider?: InputMaybe<Scalars['String']['input']>;
   provider_?: InputMaybe<Provider_Filter>;
-  provider_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_gte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_lt?: InputMaybe<Scalars["String"]["input"]>;
-  provider_lte?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  provider_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  provider_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  provider_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_gt?: InputMaybe<Scalars['String']['input']>;
+  provider_gte?: InputMaybe<Scalars['String']['input']>;
+  provider_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_lt?: InputMaybe<Scalars['String']['input']>;
+  provider_lte?: InputMaybe<Scalars['String']['input']>;
+  provider_not?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Peer_OrderBy =
-  | "capacityCommitments"
-  | "computeUnits"
-  | "currentCCCollateralDepositedAt"
-  | "currentCCEndEpoch"
-  | "currentCCNextCCFailedEpoch"
-  | "currentCapacityCommitment"
-  | "currentCapacityCommitment__activeUnitCount"
-  | "currentCapacityCommitment__collateralPerUnit"
-  | "currentCapacityCommitment__delegator"
-  | "currentCapacityCommitment__deleted"
-  | "currentCapacityCommitment__duration"
-  | "currentCapacityCommitment__endEpoch"
-  | "currentCapacityCommitment__exitedUnitCount"
-  | "currentCapacityCommitment__failedEpoch"
-  | "currentCapacityCommitment__id"
-  | "currentCapacityCommitment__nextAdditionalActiveUnitCount"
-  | "currentCapacityCommitment__nextCCFailedEpoch"
-  | "currentCapacityCommitment__rewardDelegatorRate"
-  | "currentCapacityCommitment__snapshotEpoch"
-  | "currentCapacityCommitment__startEpoch"
-  | "currentCapacityCommitment__status"
-  | "currentCapacityCommitment__totalCUFailCount"
-  | "currentCapacityCommitment__unitCount"
-  | "id"
-  | "isAnyJoinedDeals"
-  | "joinedDeals"
-  | "offer"
-  | "offer__computeUnitsAvailable"
-  | "offer__computeUnitsTotal"
-  | "offer__createdAt"
-  | "offer__id"
-  | "offer__pricePerEpoch"
-  | "offer__updatedAt"
-  | "provider"
-  | "provider__approved"
-  | "provider__computeUnitsAvailable"
-  | "provider__computeUnitsTotal"
-  | "provider__createdAt"
-  | "provider__effectorCount"
-  | "provider__id"
-  | "provider__name"
-  | "provider__peerCount";
+  | 'capacityCommitments'
+  | 'computeUnits'
+  | 'computeUnitsInCapacityCommitment'
+  | 'computeUnitsInDeal'
+  | 'computeUnitsTotal'
+  | 'currentCCCollateralDepositedAt'
+  | 'currentCCEndEpoch'
+  | 'currentCCNextCCFailedEpoch'
+  | 'currentCapacityCommitment'
+  | 'currentCapacityCommitment__activeUnitCount'
+  | 'currentCapacityCommitment__collateralPerUnit'
+  | 'currentCapacityCommitment__computeUnitsCount'
+  | 'currentCapacityCommitment__createdAt'
+  | 'currentCapacityCommitment__delegator'
+  | 'currentCapacityCommitment__deleted'
+  | 'currentCapacityCommitment__duration'
+  | 'currentCapacityCommitment__endEpoch'
+  | 'currentCapacityCommitment__exitedUnitCount'
+  | 'currentCapacityCommitment__failedEpoch'
+  | 'currentCapacityCommitment__id'
+  | 'currentCapacityCommitment__nextAdditionalActiveUnitCount'
+  | 'currentCapacityCommitment__nextCCFailedEpoch'
+  | 'currentCapacityCommitment__rewardDelegatorRate'
+  | 'currentCapacityCommitment__rewardWithdrawn'
+  | 'currentCapacityCommitment__snapshotEpoch'
+  | 'currentCapacityCommitment__startEpoch'
+  | 'currentCapacityCommitment__status'
+  | 'currentCapacityCommitment__submittedProofsCount'
+  | 'currentCapacityCommitment__totalCUFailCount'
+  | 'currentCapacityCommitment__totalCollateral'
+  | 'id'
+  | 'isAnyJoinedDeals'
+  | 'joinedDeals'
+  | 'offer'
+  | 'offer__computeUnitsAvailable'
+  | 'offer__computeUnitsTotal'
+  | 'offer__createdAt'
+  | 'offer__id'
+  | 'offer__pricePerEpoch'
+  | 'offer__updatedAt'
+  | 'provider'
+  | 'provider__approved'
+  | 'provider__computeUnitsAvailable'
+  | 'provider__computeUnitsTotal'
+  | 'provider__createdAt'
+  | 'provider__id'
+  | 'provider__name'
+  | 'provider__peerCount'
+  | 'provider__registered';
 
 export type Provider = {
-  __typename?: "Provider";
-  approved: Scalars["Boolean"]["output"];
-  computeUnitsAvailable: Scalars["Int"]["output"];
-  computeUnitsTotal: Scalars["Int"]["output"];
-  createdAt: Scalars["BigInt"]["output"];
-  effectorCount: Scalars["Int"]["output"];
-  id: Scalars["ID"]["output"];
-  name: Scalars["String"]["output"];
+  __typename?: 'Provider';
+  approved: Scalars['Boolean']['output'];
+  computeUnitsAvailable: Scalars['Int']['output'];
+  computeUnitsTotal: Scalars['Int']['output'];
+  createdAt: Scalars['BigInt']['output'];
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
   offers?: Maybe<Array<Offer>>;
-  peerCount: Scalars["Int"]["output"];
+  peerCount: Scalars['Int']['output'];
+  /** Is provider registered in the network (if false - possible just mentioned). */
+  registered: Scalars['Boolean']['output'];
 };
 
+
 export type ProviderOffersArgs = {
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Offer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   where?: InputMaybe<Offer_Filter>;
 };
 
@@ -1697,100 +2282,102 @@ export type Provider_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Provider_Filter>>>;
-  approved?: InputMaybe<Scalars["Boolean"]["input"]>;
-  approved_in?: InputMaybe<Array<Scalars["Boolean"]["input"]>>;
-  approved_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  approved_not_in?: InputMaybe<Array<Scalars["Boolean"]["input"]>>;
-  computeUnitsAvailable?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  computeUnitsAvailable_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_not?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsAvailable_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  computeUnitsTotal?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  computeUnitsTotal_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_not?: InputMaybe<Scalars["Int"]["input"]>;
-  computeUnitsTotal_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  createdAt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_gt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_gte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  createdAt_lt?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_not?: InputMaybe<Scalars["BigInt"]["input"]>;
-  createdAt_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
-  effectorCount?: InputMaybe<Scalars["Int"]["input"]>;
-  effectorCount_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  effectorCount_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  effectorCount_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  effectorCount_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  effectorCount_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  effectorCount_not?: InputMaybe<Scalars["Int"]["input"]>;
-  effectorCount_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  name_contains?: InputMaybe<Scalars["String"]["input"]>;
-  name_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  name_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  name_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  name_gt?: InputMaybe<Scalars["String"]["input"]>;
-  name_gte?: InputMaybe<Scalars["String"]["input"]>;
-  name_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  name_lt?: InputMaybe<Scalars["String"]["input"]>;
-  name_lte?: InputMaybe<Scalars["String"]["input"]>;
-  name_not?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  name_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  name_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  name_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  approved?: InputMaybe<Scalars['Boolean']['input']>;
+  approved_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  approved_not?: InputMaybe<Scalars['Boolean']['input']>;
+  approved_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  computeUnitsAvailable?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsAvailable_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsAvailable_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsTotal?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_gt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_gte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  computeUnitsTotal_lt?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_lte?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_not?: InputMaybe<Scalars['Int']['input']>;
+  computeUnitsTotal_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  createdAt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_gt?: InputMaybe<Scalars['String']['input']>;
+  name_gte?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_lt?: InputMaybe<Scalars['String']['input']>;
+  name_lte?: InputMaybe<Scalars['String']['input']>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   offers_?: InputMaybe<Offer_Filter>;
   or?: InputMaybe<Array<InputMaybe<Provider_Filter>>>;
-  peerCount?: InputMaybe<Scalars["Int"]["input"]>;
-  peerCount_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  peerCount_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  peerCount_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  peerCount_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  peerCount_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  peerCount_not?: InputMaybe<Scalars["Int"]["input"]>;
-  peerCount_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
+  peerCount?: InputMaybe<Scalars['Int']['input']>;
+  peerCount_gt?: InputMaybe<Scalars['Int']['input']>;
+  peerCount_gte?: InputMaybe<Scalars['Int']['input']>;
+  peerCount_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  peerCount_lt?: InputMaybe<Scalars['Int']['input']>;
+  peerCount_lte?: InputMaybe<Scalars['Int']['input']>;
+  peerCount_not?: InputMaybe<Scalars['Int']['input']>;
+  peerCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  registered?: InputMaybe<Scalars['Boolean']['input']>;
+  registered_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  registered_not?: InputMaybe<Scalars['Boolean']['input']>;
+  registered_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
 };
 
 export type Provider_OrderBy =
-  | "approved"
-  | "computeUnitsAvailable"
-  | "computeUnitsTotal"
-  | "createdAt"
-  | "effectorCount"
-  | "id"
-  | "name"
-  | "offers"
-  | "peerCount";
+  | 'approved'
+  | 'computeUnitsAvailable'
+  | 'computeUnitsTotal'
+  | 'createdAt'
+  | 'id'
+  | 'name'
+  | 'offers'
+  | 'peerCount'
+  | 'registered';
 
 export type Query = {
-  __typename?: "Query";
+  __typename?: 'Query';
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
   capacityCommitment?: Maybe<CapacityCommitment>;
+  capacityCommitmentStatsPerEpoch?: Maybe<CapacityCommitmentStatsPerEpoch>;
+  capacityCommitmentStatsPerEpoches: Array<CapacityCommitmentStatsPerEpoch>;
+  capacityCommitmentToComputeUnit?: Maybe<CapacityCommitmentToComputeUnit>;
+  capacityCommitmentToComputeUnits: Array<CapacityCommitmentToComputeUnit>;
   capacityCommitments: Array<CapacityCommitment>;
   computeUnit?: Maybe<ComputeUnit>;
+  computeUnitPerEpochStat?: Maybe<ComputeUnitPerEpochStat>;
+  computeUnitPerEpochStats: Array<ComputeUnitPerEpochStat>;
   computeUnits: Array<ComputeUnit>;
   deal?: Maybe<Deal>;
   dealToEffector?: Maybe<DealToEffector>;
@@ -1814,245 +2401,577 @@ export type Query = {
   peers: Array<Peer>;
   provider?: Maybe<Provider>;
   providers: Array<Provider>;
+  submittedProof?: Maybe<SubmittedProof>;
+  submittedProofs: Array<SubmittedProof>;
   token?: Maybe<Token>;
   tokens: Array<Token>;
 };
+
 
 export type Query_MetaArgs = {
   block?: InputMaybe<Block_Height>;
 };
 
+
 export type QueryCapacityCommitmentArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
+export type QueryCapacityCommitmentStatsPerEpochArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryCapacityCommitmentStatsPerEpochesArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<CapacityCommitmentStatsPerEpoch_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<CapacityCommitmentStatsPerEpoch_Filter>;
+};
+
+
+export type QueryCapacityCommitmentToComputeUnitArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryCapacityCommitmentToComputeUnitsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<CapacityCommitmentToComputeUnit_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<CapacityCommitmentToComputeUnit_Filter>;
+};
+
+
 export type QueryCapacityCommitmentsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<CapacityCommitment_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<CapacityCommitment_Filter>;
 };
 
+
 export type QueryComputeUnitArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
+export type QueryComputeUnitPerEpochStatArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryComputeUnitPerEpochStatsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ComputeUnitPerEpochStat_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<ComputeUnitPerEpochStat_Filter>;
+};
+
+
 export type QueryComputeUnitsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<ComputeUnit_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<ComputeUnit_Filter>;
 };
 
+
 export type QueryDealArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
+
 
 export type QueryDealToEffectorArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryDealToEffectorsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToEffector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToEffector_Filter>;
 };
 
+
 export type QueryDealToJoinedOfferPeerArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryDealToJoinedOfferPeersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToJoinedOfferPeer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToJoinedOfferPeer_Filter>;
 };
 
+
 export type QueryDealToPeerArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryDealToPeersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToPeer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToPeer_Filter>;
 };
 
+
 export type QueryDealToProvidersAccessArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryDealToProvidersAccessesArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToProvidersAccess_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToProvidersAccess_Filter>;
 };
 
+
 export type QueryDealsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Deal_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Deal_Filter>;
 };
 
+
 export type QueryEffectorArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryEffectorsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Effector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Effector_Filter>;
 };
 
+
 export type QueryGraphNetworkArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryGraphNetworksArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<GraphNetwork_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<GraphNetwork_Filter>;
 };
 
+
 export type QueryOfferArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
+
 
 export type QueryOfferToEffectorArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryOfferToEffectorsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<OfferToEffector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<OfferToEffector_Filter>;
 };
 
+
 export type QueryOffersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Offer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Offer_Filter>;
 };
 
+
 export type QueryPeerArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryPeersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Peer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Peer_Filter>;
 };
 
+
 export type QueryProviderArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryProvidersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Provider_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Provider_Filter>;
 };
 
-export type QueryTokenArgs = {
+
+export type QuerySubmittedProofArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
+export type QuerySubmittedProofsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<SubmittedProof_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<SubmittedProof_Filter>;
+};
+
+
+export type QueryTokenArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
 export type QueryTokensArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Token_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Token_Filter>;
 };
 
+export type SubmittedProof = {
+  __typename?: 'SubmittedProof';
+  capacityCommitment: CapacityCommitment;
+  capacityCommitmentStatsPerEpoch: CapacityCommitmentStatsPerEpoch;
+  computeUnit: ComputeUnit;
+  createdAt: Scalars['BigInt']['output'];
+  createdEpoch: Scalars['BigInt']['output'];
+  /** Id here is a transaction hash. */
+  id: Scalars['ID']['output'];
+  localUnitNonce: Scalars['Bytes']['output'];
+  peer: Peer;
+  provider: Provider;
+};
+
+export type SubmittedProof_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<SubmittedProof_Filter>>>;
+  capacityCommitment?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_?: InputMaybe<CapacityCommitmentStatsPerEpoch_Filter>;
+  capacityCommitmentStatsPerEpoch_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_gt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_gte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitmentStatsPerEpoch_lt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_lte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_not?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_not_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitmentStatsPerEpoch_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitmentStatsPerEpoch_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_?: InputMaybe<CapacityCommitment_Filter>;
+  capacityCommitment_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_gte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_lt?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_lte?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  capacityCommitment_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
+  capacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_?: InputMaybe<ComputeUnit_Filter>;
+  computeUnit_contains?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_ends_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_gt?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_gte?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  computeUnit_lt?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_lte?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_contains?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  computeUnit_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_starts_with?: InputMaybe<Scalars['String']['input']>;
+  computeUnit_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  createdAt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAt_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAt_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdEpoch?: InputMaybe<Scalars['BigInt']['input']>;
+  createdEpoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdEpoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdEpoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdEpoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdEpoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
+  createdEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  localUnitNonce?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  localUnitNonce_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_not?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  localUnitNonce_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<SubmittedProof_Filter>>>;
+  peer?: InputMaybe<Scalars['String']['input']>;
+  peer_?: InputMaybe<Peer_Filter>;
+  peer_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_gt?: InputMaybe<Scalars['String']['input']>;
+  peer_gte?: InputMaybe<Scalars['String']['input']>;
+  peer_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_lt?: InputMaybe<Scalars['String']['input']>;
+  peer_lte?: InputMaybe<Scalars['String']['input']>;
+  peer_not?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  peer_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  peer_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with?: InputMaybe<Scalars['String']['input']>;
+  peer_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider?: InputMaybe<Scalars['String']['input']>;
+  provider_?: InputMaybe<Provider_Filter>;
+  provider_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_gt?: InputMaybe<Scalars['String']['input']>;
+  provider_gte?: InputMaybe<Scalars['String']['input']>;
+  provider_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_lt?: InputMaybe<Scalars['String']['input']>;
+  provider_lte?: InputMaybe<Scalars['String']['input']>;
+  provider_not?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains?: InputMaybe<Scalars['String']['input']>;
+  provider_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  provider_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with?: InputMaybe<Scalars['String']['input']>;
+  provider_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type SubmittedProof_OrderBy =
+  | 'capacityCommitment'
+  | 'capacityCommitmentStatsPerEpoch'
+  | 'capacityCommitmentStatsPerEpoch__activeUnitCount'
+  | 'capacityCommitmentStatsPerEpoch__blockNumberEnd'
+  | 'capacityCommitmentStatsPerEpoch__blockNumberStart'
+  | 'capacityCommitmentStatsPerEpoch__computeUnitsWithMinRequiredProofsSubmittedCounter'
+  | 'capacityCommitmentStatsPerEpoch__currentCCNextCCFailedEpoch'
+  | 'capacityCommitmentStatsPerEpoch__epoch'
+  | 'capacityCommitmentStatsPerEpoch__exitedUnitCount'
+  | 'capacityCommitmentStatsPerEpoch__id'
+  | 'capacityCommitmentStatsPerEpoch__nextAdditionalActiveUnitCount'
+  | 'capacityCommitmentStatsPerEpoch__submittedProofsCount'
+  | 'capacityCommitmentStatsPerEpoch__totalCUFailCount'
+  | 'capacityCommitment__activeUnitCount'
+  | 'capacityCommitment__collateralPerUnit'
+  | 'capacityCommitment__computeUnitsCount'
+  | 'capacityCommitment__createdAt'
+  | 'capacityCommitment__delegator'
+  | 'capacityCommitment__deleted'
+  | 'capacityCommitment__duration'
+  | 'capacityCommitment__endEpoch'
+  | 'capacityCommitment__exitedUnitCount'
+  | 'capacityCommitment__failedEpoch'
+  | 'capacityCommitment__id'
+  | 'capacityCommitment__nextAdditionalActiveUnitCount'
+  | 'capacityCommitment__nextCCFailedEpoch'
+  | 'capacityCommitment__rewardDelegatorRate'
+  | 'capacityCommitment__rewardWithdrawn'
+  | 'capacityCommitment__snapshotEpoch'
+  | 'capacityCommitment__startEpoch'
+  | 'capacityCommitment__status'
+  | 'capacityCommitment__submittedProofsCount'
+  | 'capacityCommitment__totalCUFailCount'
+  | 'capacityCommitment__totalCollateral'
+  | 'computeUnit'
+  | 'computeUnit__createdAt'
+  | 'computeUnit__id'
+  | 'computeUnit__submittedProofsCount'
+  | 'computeUnit__workerId'
+  | 'createdAt'
+  | 'createdEpoch'
+  | 'id'
+  | 'localUnitNonce'
+  | 'peer'
+  | 'peer__computeUnitsInCapacityCommitment'
+  | 'peer__computeUnitsInDeal'
+  | 'peer__computeUnitsTotal'
+  | 'peer__currentCCCollateralDepositedAt'
+  | 'peer__currentCCEndEpoch'
+  | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__id'
+  | 'peer__isAnyJoinedDeals'
+  | 'provider'
+  | 'provider__approved'
+  | 'provider__computeUnitsAvailable'
+  | 'provider__computeUnitsTotal'
+  | 'provider__createdAt'
+  | 'provider__id'
+  | 'provider__name'
+  | 'provider__peerCount'
+  | 'provider__registered';
+
 export type Subscription = {
-  __typename?: "Subscription";
+  __typename?: 'Subscription';
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
   capacityCommitment?: Maybe<CapacityCommitment>;
+  capacityCommitmentStatsPerEpoch?: Maybe<CapacityCommitmentStatsPerEpoch>;
+  capacityCommitmentStatsPerEpoches: Array<CapacityCommitmentStatsPerEpoch>;
+  capacityCommitmentToComputeUnit?: Maybe<CapacityCommitmentToComputeUnit>;
+  capacityCommitmentToComputeUnits: Array<CapacityCommitmentToComputeUnit>;
   capacityCommitments: Array<CapacityCommitment>;
   computeUnit?: Maybe<ComputeUnit>;
+  computeUnitPerEpochStat?: Maybe<ComputeUnitPerEpochStat>;
+  computeUnitPerEpochStats: Array<ComputeUnitPerEpochStat>;
   computeUnits: Array<ComputeUnit>;
   deal?: Maybe<Deal>;
   dealToEffector?: Maybe<DealToEffector>;
@@ -2076,303 +2995,411 @@ export type Subscription = {
   peers: Array<Peer>;
   provider?: Maybe<Provider>;
   providers: Array<Provider>;
+  submittedProof?: Maybe<SubmittedProof>;
+  submittedProofs: Array<SubmittedProof>;
   token?: Maybe<Token>;
   tokens: Array<Token>;
 };
+
 
 export type Subscription_MetaArgs = {
   block?: InputMaybe<Block_Height>;
 };
 
+
 export type SubscriptionCapacityCommitmentArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
+export type SubscriptionCapacityCommitmentStatsPerEpochArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionCapacityCommitmentStatsPerEpochesArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<CapacityCommitmentStatsPerEpoch_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<CapacityCommitmentStatsPerEpoch_Filter>;
+};
+
+
+export type SubscriptionCapacityCommitmentToComputeUnitArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionCapacityCommitmentToComputeUnitsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<CapacityCommitmentToComputeUnit_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<CapacityCommitmentToComputeUnit_Filter>;
+};
+
+
 export type SubscriptionCapacityCommitmentsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<CapacityCommitment_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<CapacityCommitment_Filter>;
 };
 
+
 export type SubscriptionComputeUnitArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
+export type SubscriptionComputeUnitPerEpochStatArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionComputeUnitPerEpochStatsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<ComputeUnitPerEpochStat_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<ComputeUnitPerEpochStat_Filter>;
+};
+
+
 export type SubscriptionComputeUnitsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<ComputeUnit_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<ComputeUnit_Filter>;
 };
 
+
 export type SubscriptionDealArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
+
 
 export type SubscriptionDealToEffectorArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionDealToEffectorsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToEffector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToEffector_Filter>;
 };
 
+
 export type SubscriptionDealToJoinedOfferPeerArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionDealToJoinedOfferPeersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToJoinedOfferPeer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToJoinedOfferPeer_Filter>;
 };
 
+
 export type SubscriptionDealToPeerArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionDealToPeersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToPeer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToPeer_Filter>;
 };
 
+
 export type SubscriptionDealToProvidersAccessArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionDealToProvidersAccessesArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<DealToProvidersAccess_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<DealToProvidersAccess_Filter>;
 };
 
+
 export type SubscriptionDealsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Deal_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Deal_Filter>;
 };
 
+
 export type SubscriptionEffectorArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionEffectorsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Effector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Effector_Filter>;
 };
 
+
 export type SubscriptionGraphNetworkArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionGraphNetworksArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<GraphNetwork_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<GraphNetwork_Filter>;
 };
 
+
 export type SubscriptionOfferArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
+
 
 export type SubscriptionOfferToEffectorArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionOfferToEffectorsArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<OfferToEffector_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<OfferToEffector_Filter>;
 };
 
+
 export type SubscriptionOffersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Offer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Offer_Filter>;
 };
 
+
 export type SubscriptionPeerArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionPeersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Peer_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Peer_Filter>;
 };
 
+
 export type SubscriptionProviderArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionProvidersArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Provider_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Provider_Filter>;
 };
 
-export type SubscriptionTokenArgs = {
+
+export type SubscriptionSubmittedProofArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"]["input"];
+  id: Scalars['ID']['input'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
+export type SubscriptionSubmittedProofsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<SubmittedProof_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<SubmittedProof_Filter>;
+};
+
+
+export type SubscriptionTokenArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
 export type SubscriptionTokensArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]["input"]>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Token_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Token_Filter>;
 };
 
 export type Token = {
-  __typename?: "Token";
-  decimals: Scalars["Int"]["output"];
-  id: Scalars["ID"]["output"];
-  symbol: Scalars["String"]["output"];
+  __typename?: 'Token';
+  decimals: Scalars['Int']['output'];
+  id: Scalars['ID']['output'];
+  symbol: Scalars['String']['output'];
 };
 
 export type Token_Filter = {
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Token_Filter>>>;
-  decimals?: InputMaybe<Scalars["Int"]["input"]>;
-  decimals_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  decimals_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  decimals_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  decimals_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  decimals_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  decimals_not?: InputMaybe<Scalars["Int"]["input"]>;
-  decimals_not_in?: InputMaybe<Array<Scalars["Int"]["input"]>>;
-  id?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_gte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
-  id_lt?: InputMaybe<Scalars["ID"]["input"]>;
-  id_lte?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not?: InputMaybe<Scalars["ID"]["input"]>;
-  id_not_in?: InputMaybe<Array<Scalars["ID"]["input"]>>;
+  decimals?: InputMaybe<Scalars['Int']['input']>;
+  decimals_gt?: InputMaybe<Scalars['Int']['input']>;
+  decimals_gte?: InputMaybe<Scalars['Int']['input']>;
+  decimals_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  decimals_lt?: InputMaybe<Scalars['Int']['input']>;
+  decimals_lte?: InputMaybe<Scalars['Int']['input']>;
+  decimals_not?: InputMaybe<Scalars['Int']['input']>;
+  decimals_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   or?: InputMaybe<Array<InputMaybe<Token_Filter>>>;
-  symbol?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_contains?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_gt?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_gte?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  symbol_lt?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_lte?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_not?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_not_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_not_ends_with?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_not_ends_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_not_in?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  symbol_not_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_not_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_starts_with?: InputMaybe<Scalars["String"]["input"]>;
-  symbol_starts_with_nocase?: InputMaybe<Scalars["String"]["input"]>;
+  symbol?: InputMaybe<Scalars['String']['input']>;
+  symbol_contains?: InputMaybe<Scalars['String']['input']>;
+  symbol_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  symbol_ends_with?: InputMaybe<Scalars['String']['input']>;
+  symbol_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  symbol_gt?: InputMaybe<Scalars['String']['input']>;
+  symbol_gte?: InputMaybe<Scalars['String']['input']>;
+  symbol_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  symbol_lt?: InputMaybe<Scalars['String']['input']>;
+  symbol_lte?: InputMaybe<Scalars['String']['input']>;
+  symbol_not?: InputMaybe<Scalars['String']['input']>;
+  symbol_not_contains?: InputMaybe<Scalars['String']['input']>;
+  symbol_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  symbol_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  symbol_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  symbol_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  symbol_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  symbol_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  symbol_starts_with?: InputMaybe<Scalars['String']['input']>;
+  symbol_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type Token_OrderBy = "decimals" | "id" | "symbol";
+export type Token_OrderBy =
+  | 'decimals'
+  | 'id'
+  | 'symbol';
 
 export type _Block_ = {
-  __typename?: "_Block_";
+  __typename?: '_Block_';
   /** The hash of the block */
-  hash?: Maybe<Scalars["Bytes"]["output"]>;
+  hash?: Maybe<Scalars['Bytes']['output']>;
   /** The block number */
-  number: Scalars["Int"]["output"];
+  number: Scalars['Int']['output'];
+  /** The hash of the parent block */
+  parentHash?: Maybe<Scalars['Bytes']['output']>;
   /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars["Int"]["output"]>;
+  timestamp?: Maybe<Scalars['Int']['output']>;
 };
 
 /** The type for the top-level _meta field */
 export type _Meta_ = {
-  __typename?: "_Meta_";
+  __typename?: '_Meta_';
   /**
    * Information about a specific subgraph block. The hash of the block
    * will be null if the _meta field has a block constraint that asks for
@@ -2382,13 +3409,13 @@ export type _Meta_ = {
    */
   block: _Block_;
   /** The deployment ID */
-  deployment: Scalars["String"]["output"];
+  deployment: Scalars['String']['output'];
   /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars["Boolean"]["output"];
+  hasIndexingErrors: Scalars['Boolean']['output'];
 };
 
 export type _SubgraphErrorPolicy_ =
   /** Data will be returned even if the subgraph has indexing errors */
-  | "allow"
+  | 'allow'
   /** If the subgraph has indexing errors, data will be omitted. The default. */
-  | "deny";
+  | 'deny';

--- a/ts-client/src/dealMatcherClient/indexerClient/queries/deals-query.generated.ts
+++ b/ts-client/src/dealMatcherClient/indexerClient/queries/deals-query.generated.ts
@@ -7,118 +7,64 @@ import type { RequestOptions } from "graphql-request";
 type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
 import gql from "graphql-tag";
 export type DealQueryQueryVariables = Types.Exact<{
-  id: Types.Scalars["ID"]["input"];
+  id: Types.Scalars['ID']['input'];
 }>;
 
-export type DealQueryQuery = {
-  __typename?: "Query";
-  deal?: {
-    __typename?: "Deal";
-    id: string;
-    maxWorkersPerProvider: number;
-    minWorkers: number;
-    pricePerWorkerEpoch: any;
-    targetWorkers: number;
-    providersAccessType: number;
-    paymentToken: { __typename?: "Token"; id: string };
-    addedComputeUnits?: Array<{
-      __typename?: "ComputeUnit";
-      id: string;
-      provider: { __typename?: "Provider"; id: string };
-    }> | null;
-    effectors?: Array<{
-      __typename?: "DealToEffector";
-      effector: { __typename?: "Effector"; id: string };
-    }> | null;
-    providersAccessList?: Array<{
-      __typename?: "DealToProvidersAccess";
-      id: string;
-    }> | null;
-  } | null;
-  _meta?: {
-    __typename?: "_Meta_";
-    block: { __typename?: "_Block_"; timestamp?: number | null };
-  } | null;
-  graphNetworks: Array<{
-    __typename?: "GraphNetwork";
-    coreEpochDuration?: number | null;
-    initTimestamp?: number | null;
-  }>;
-};
+
+export type DealQueryQuery = { __typename?: 'Query', deal?: { __typename?: 'Deal', id: string, maxWorkersPerProvider: number, minWorkers: number, pricePerWorkerEpoch: any, targetWorkers: number, providersAccessType: number, paymentToken: { __typename?: 'Token', id: string }, addedComputeUnits?: Array<{ __typename?: 'ComputeUnit', id: string, provider: { __typename?: 'Provider', id: string } }> | null, effectors?: Array<{ __typename?: 'DealToEffector', effector: { __typename?: 'Effector', id: string } }> | null, providersAccessList?: Array<{ __typename?: 'DealToProvidersAccess', provider: { __typename?: 'Provider', id: string } }> | null } | null, _meta?: { __typename?: '_Meta_', block: { __typename?: '_Block_', timestamp?: number | null } } | null, graphNetworks: Array<{ __typename?: 'GraphNetwork', coreEpochDuration?: number | null, initTimestamp?: number | null }> };
+
 
 export const DealQueryDocument = gql`
-  query DealQuery($id: ID!) {
-    deal(id: $id) {
+    query DealQuery($id: ID!) {
+  deal(id: $id) {
+    id
+    maxWorkersPerProvider
+    minWorkers
+    pricePerWorkerEpoch
+    paymentToken {
       id
-      maxWorkersPerProvider
-      minWorkers
-      pricePerWorkerEpoch
-      paymentToken {
-        id
-      }
-      targetWorkers
-      addedComputeUnits {
-        id
-        provider {
-          id
-        }
-      }
-      effectors {
-        effector {
-          id
-        }
-      }
-      providersAccessType
-      providersAccessList {
+    }
+    targetWorkers
+    addedComputeUnits {
+      id
+      provider {
         id
       }
     }
-    _meta {
-      block {
-        timestamp
+    effectors {
+      effector {
+        id
       }
     }
-    graphNetworks(first: 1) {
-      coreEpochDuration
-      initTimestamp
+    providersAccessType
+    providersAccessList {
+      provider {
+        id
+      }
     }
   }
-`;
+  _meta {
+    block {
+      timestamp
+    }
+  }
+  graphNetworks(first: 1) {
+    coreEpochDuration
+    initTimestamp
+  }
+}
+    `;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string,
-  variables?: any,
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType,
-  variables,
-) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper,
-) {
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
+
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    DealQuery(
-      variables: DealQueryQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<DealQueryQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<DealQueryQuery>(DealQueryDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        "DealQuery",
-        "query",
-        variables,
-      );
-    },
+    DealQuery(variables: DealQueryQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DealQueryQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DealQueryQuery>(DealQueryDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'DealQuery', 'query', variables);
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/ts-client/src/dealMatcherClient/indexerClient/queries/deals-query.graphql
+++ b/ts-client/src/dealMatcherClient/indexerClient/queries/deals-query.graphql
@@ -23,7 +23,9 @@ query DealQuery(
     }
     providersAccessType
     providersAccessList {
-      id
+      provider {
+        id
+      }
     }
   }
 

--- a/ts-client/src/dealMatcherClient/indexerClient/queries/offers-query.generated.ts
+++ b/ts-client/src/dealMatcherClient/indexerClient/queries/offers-query.generated.ts
@@ -10,99 +10,54 @@ export type OffersQueryQueryVariables = Types.Exact<{
   filters?: Types.InputMaybe<Types.Offer_Filter>;
   peersFilters?: Types.InputMaybe<Types.Peer_Filter>;
   computeUnitsFilters?: Types.InputMaybe<Types.ComputeUnit_Filter>;
-  peersLimit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  computeUnitsLimit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  offset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  peersOffset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  computeUnitsOffset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  limit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  peersLimit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  computeUnitsLimit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  offset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  peersOffset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  computeUnitsOffset?: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  limit?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   orderBy?: Types.InputMaybe<Types.Offer_OrderBy>;
   orderType?: Types.InputMaybe<Types.OrderDirection>;
 }>;
 
-export type OffersQueryQuery = {
-  __typename?: "Query";
-  offers: Array<{
-    __typename?: "Offer";
-    id: string;
-    peers?: Array<{
-      __typename?: "Peer";
-      id: string;
-      computeUnits?: Array<{ __typename?: "ComputeUnit"; id: string }> | null;
-    }> | null;
-  }>;
-};
+
+export type OffersQueryQuery = { __typename?: 'Query', offers: Array<{ __typename?: 'Offer', id: string, peers?: Array<{ __typename?: 'Peer', id: string, computeUnits?: Array<{ __typename?: 'ComputeUnit', id: string }> | null }> | null }> };
+
 
 export const OffersQueryDocument = gql`
-  query OffersQuery(
-    $filters: Offer_filter
-    $peersFilters: Peer_filter
-    $computeUnitsFilters: ComputeUnit_filter
-    $peersLimit: Int
-    $computeUnitsLimit: Int
-    $offset: Int
-    $peersOffset: Int
-    $computeUnitsOffset: Int
-    $limit: Int
-    $orderBy: Offer_orderBy
-    $orderType: OrderDirection
+    query OffersQuery($filters: Offer_filter, $peersFilters: Peer_filter, $computeUnitsFilters: ComputeUnit_filter, $peersLimit: Int, $computeUnitsLimit: Int, $offset: Int, $peersOffset: Int, $computeUnitsOffset: Int, $limit: Int, $orderBy: Offer_orderBy, $orderType: OrderDirection) {
+  offers(
+    where: $filters
+    first: $limit
+    skip: $offset
+    orderBy: $orderBy
+    orderDirection: $orderType
   ) {
-    offers(
-      where: $filters
-      first: $limit
-      skip: $offset
-      orderBy: $orderBy
-      orderDirection: $orderType
-    ) {
+    id
+    peers(where: $peersFilters, first: $peersLimit, skip: $peersOffset) {
       id
-      peers(where: $peersFilters, first: $peersLimit, skip: $peersOffset) {
+      computeUnits(
+        where: $computeUnitsFilters
+        first: $computeUnitsLimit
+        skip: $computeUnitsOffset
+      ) {
         id
-        computeUnits(
-          where: $computeUnitsFilters
-          first: $computeUnitsLimit
-          skip: $computeUnitsOffset
-        ) {
-          id
-        }
       }
     }
   }
-`;
+}
+    `;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string,
-  variables?: any,
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType,
-  variables,
-) => action();
 
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper,
-) {
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
+
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    OffersQuery(
-      variables?: OffersQueryQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<OffersQueryQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<OffersQueryQuery>(OffersQueryDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        "OffersQuery",
-        "query",
-        variables,
-      );
-    },
+    OffersQuery(variables?: OffersQueryQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<OffersQueryQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<OffersQueryQuery>(OffersQueryDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'OffersQuery', 'query', variables);
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/ts-client/src/utils/serializers.ts
+++ b/ts-client/src/utils/serializers.ts
@@ -1,12 +1,9 @@
 export function serializeDealProviderAccessLists(
   providersAccessType: number,
-  providersAccessList:
-    | Array<{
-        __typename?: "DealToProvidersAccess";
-        id: string;
-      }>
-    | null
-    | undefined,
+  providersAccessList: Array<{
+    __typename?: "DealToProvidersAccess";
+    provider: { __typename?: "Provider"; id: string }
+  }> | null | undefined
 ): { whitelist: Array<string>; blacklist: Array<string> } {
   const res: { whitelist: Array<string>; blacklist: Array<string> } = {
     whitelist: [],
@@ -17,7 +14,7 @@ export function serializeDealProviderAccessLists(
     return res;
   }
   const providersAccessListStrings = providersAccessList.map((providerObj) => {
-    return providerObj.id;
+    return providerObj.provider.id;
   });
   if (providersAccessType == 1) {
     // whitelist

--- a/ts-client/tests/integration/scripts/create-pure-market.test.ts
+++ b/ts-client/tests/integration/scripts/create-pure-market.test.ts
@@ -379,6 +379,7 @@ async function main() {
     // We want to match with 2 CU and according to protocol restriction them should be from different peers
     // TODO: need to resolve this: https://linear.app/fluence/issue/CHAIN-400/bug-in-matchermatchdeal-when-match-with-whitelisted-deal
     //  or rewrite match with CUs with active CC.
+    console.log('marketFixture.dealToMatchWithWhiteListedProvider.dealId', marketFixture.dealToMatchWithWhiteListedProvider.dealId)
     const matchDealTx = await marketContract.matchDeal(
         marketFixture.dealToMatchWithWhiteListedProvider.dealId!,
         [marketFixture.providerToBeMatched.offerId!, marketFixture.providerToBeMatched.offerId!],


### PR DESCRIPTION
# ChangeLog
- Subgraph: @AlcibiadesCleinias
[fix handleComputeUnitAddedToDeal](https://github.com/fluencelabs/deal/pull/314/commits/0b9c27590354d23d015ccdae670e8f944ae34755)
- Subgraph: [fix for ComputeUnitPerEpochStat model](https://github.com/fluencelabs/deal/pull/314/commits/aeba0f9738c078e8ab95cb28b13645be4c434386)
- Subgraph: ...
- DealMatcherClient: introduce new error: `DealAlreadyMatchedError` (when no need to rematch)
- Subgraph: use toHexString instead of toHex

#Checklist
- [x] check that rematch works
- [x] check counters via pure market script and graphql