### PR TITLE
fix: dealExplorerClient counters in Peer page and negative CU in CC [chain 397]

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -128,8 +128,6 @@ type Peer @entity {
   computeUnitsTotal: Int!
   "Compute units in any deals: update only when moved to deal or out."
   computeUnitsInDeal: Int!
-  "Compute units in any cc: update only when moved to CC or out: {UnitActivated, UnitDeactivated}."
-  computeUnitsInCapacityCommitment: Int!
 }
 
 type ComputeUnit @entity {

--- a/subgraph/src/mappings/capacity.ts
+++ b/subgraph/src/mappings/capacity.ts
@@ -230,24 +230,10 @@ export function handleCommitmentStatsUpdated(event: CommitmentStatsUpdated): voi
   capacityCommitmentStatsPerEpoch.save();
 }
 
-// Use this event to only check activation/deactivation for the exact unit.
-// Do not update commitment.activeUnitCount as it is updated in handleCommitmentStatsUpdated.
 export function handleUnitActivated(event: UnitActivated): void {
-  let computeUnit = ComputeUnit.load(event.params.unitId.toHexString()) as ComputeUnit;
-  let peer = Peer.load(computeUnit.peer) as Peer;
-
-  peer.computeUnitsInCapacityCommitment = peer.computeUnitsInCapacityCommitment + 1;
-  peer.save();
 }
 
-// Use this event to only check activation/deactivation for the exact unit.
-// Do not update commitment.activeUnitCount as it is updated in handleCommitmentStatsUpdated.
 export function handleUnitDeactivated(event: UnitDeactivated): void {
-  let computeUnit = ComputeUnit.load(event.params.unitId.toHexString()) as ComputeUnit;
-  let peer = Peer.load(computeUnit.peer) as Peer;
-
-  peer.computeUnitsInCapacityCommitment = peer.computeUnitsInCapacityCommitment - 1;
-  peer.save();
 }
 
 export function handleProofSubmitted(event: ProofSubmitted): void {

--- a/subgraph/src/mappings/market.ts
+++ b/subgraph/src/mappings/market.ts
@@ -153,7 +153,6 @@ export function handleComputeUnitCreated(event: ComputeUnitCreated): void {
   offer.save();
 }
 
-// It updates Peer and Offer.
 export function handlePeerCreated(event: PeerCreated): void {
   const peer = new Peer(event.params.peerId.toHexString());
   const offer = Offer.load(event.params.offerId.toHexString()) as Offer;
@@ -169,7 +168,6 @@ export function handlePeerCreated(event: PeerCreated): void {
   // Init stats below.
   peer.computeUnitsTotal = 0;
   peer.computeUnitsInDeal = 0;
-  peer.computeUnitsInCapacityCommitment = 0;
   peer.save();
 }
 

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -891,7 +891,7 @@ export class DealExplorerClient {
       providerId: peer.provider.id,
       offerId: peer.offer.id,
       computeUnitsInDeal: peer.computeUnitsInDeal,
-      computeUnitsInCapacityCommitment: peer.computeUnitsInCapacityCommitment,
+      computeUnitsInCapacityCommitment: peer.currentCapacityCommitment ? peer.currentCapacityCommitment?.activeUnitCount : 0,
       computeUnitsTotal: peer.computeUnitsTotal,
     };
   }

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -920,7 +920,7 @@ export class DealExplorerClient {
     if (
       data.peer == undefined ||
       data.peer.joinedDeals == undefined ||
-      data.peer.joinedDeals?.length == 0
+      data.peer.joinedDeals.length == 0
     ) {
       return {
         data: [],

--- a/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
@@ -617,7 +617,6 @@ export type CapacityCommitment_OrderBy =
   | 'nextAdditionalActiveUnitCount'
   | 'nextCCFailedEpoch'
   | 'peer'
-  | 'peer__computeUnitsInCapacityCommitment'
   | 'peer__computeUnitsInDeal'
   | 'peer__computeUnitsTotal'
   | 'peer__currentCCCollateralDepositedAt'
@@ -915,7 +914,6 @@ export type ComputeUnit_OrderBy =
   | 'deal__withdrawalSum'
   | 'id'
   | 'peer'
-  | 'peer__computeUnitsInCapacityCommitment'
   | 'peer__computeUnitsInDeal'
   | 'peer__computeUnitsTotal'
   | 'peer__currentCCCollateralDepositedAt'
@@ -1201,7 +1199,6 @@ export type DealToJoinedOfferPeer_OrderBy =
   | 'offer__pricePerEpoch'
   | 'offer__updatedAt'
   | 'peer'
-  | 'peer__computeUnitsInCapacityCommitment'
   | 'peer__computeUnitsInDeal'
   | 'peer__computeUnitsTotal'
   | 'peer__currentCCCollateralDepositedAt'
@@ -1303,7 +1300,6 @@ export type DealToPeer_OrderBy =
   | 'deal__withdrawalSum'
   | 'id'
   | 'peer'
-  | 'peer__computeUnitsInCapacityCommitment'
   | 'peer__computeUnitsInDeal'
   | 'peer__computeUnitsTotal'
   | 'peer__currentCCCollateralDepositedAt'
@@ -2130,8 +2126,6 @@ export type Peer = {
   /** To access history of capacity commitments. */
   capacityCommitments?: Maybe<Array<CapacityCommitment>>;
   computeUnits?: Maybe<Array<ComputeUnit>>;
-  /** Compute units in any cc: update only when moved to CC or out: {UnitActivated, UnitDeactivated}. */
-  computeUnitsInCapacityCommitment: Scalars['Int']['output'];
   /** Compute units in any deals: update only when moved to deal or out. */
   computeUnitsInDeal: Scalars['Int']['output'];
   computeUnitsTotal: Scalars['Int']['output'];
@@ -2180,14 +2174,6 @@ export type Peer_Filter = {
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Peer_Filter>>>;
   capacityCommitments_?: InputMaybe<CapacityCommitment_Filter>;
-  computeUnitsInCapacityCommitment?: InputMaybe<Scalars['Int']['input']>;
-  computeUnitsInCapacityCommitment_gt?: InputMaybe<Scalars['Int']['input']>;
-  computeUnitsInCapacityCommitment_gte?: InputMaybe<Scalars['Int']['input']>;
-  computeUnitsInCapacityCommitment_in?: InputMaybe<Array<Scalars['Int']['input']>>;
-  computeUnitsInCapacityCommitment_lt?: InputMaybe<Scalars['Int']['input']>;
-  computeUnitsInCapacityCommitment_lte?: InputMaybe<Scalars['Int']['input']>;
-  computeUnitsInCapacityCommitment_not?: InputMaybe<Scalars['Int']['input']>;
-  computeUnitsInCapacityCommitment_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   computeUnitsInDeal?: InputMaybe<Scalars['Int']['input']>;
   computeUnitsInDeal_gt?: InputMaybe<Scalars['Int']['input']>;
   computeUnitsInDeal_gte?: InputMaybe<Scalars['Int']['input']>;
@@ -2311,7 +2297,6 @@ export type Peer_Filter = {
 export type Peer_OrderBy =
   | 'capacityCommitments'
   | 'computeUnits'
-  | 'computeUnitsInCapacityCommitment'
   | 'computeUnitsInDeal'
   | 'computeUnitsTotal'
   | 'currentCCCollateralDepositedAt'
@@ -3045,7 +3030,6 @@ export type SubmittedProof_OrderBy =
   | 'id'
   | 'localUnitNonce'
   | 'peer'
-  | 'peer__computeUnitsInCapacityCommitment'
   | 'peer__computeUnitsInDeal'
   | 'peer__computeUnitsTotal'
   | 'peer__currentCCCollateralDepositedAt'

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
@@ -128,7 +128,7 @@ export const DealsByPeerQueryDocument = gql`
     ) {
       deal {
         id
-        addedComputeUnits {
+        addedComputeUnits(where: {peer_: {id: $peerId}}) {
           id
           workerId
         }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
@@ -92,7 +92,9 @@ query DealsByPeerQuery(
     ) {
       deal {
         id
-        addedComputeUnits {
+        addedComputeUnits(
+          where: {peer_: {id: $peerId}}
+        ) {
           id
           workerId
         }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.generated.ts
@@ -11,7 +11,7 @@ export type PeerQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type PeerQueryQuery = { __typename?: 'Query', peer?: { __typename?: 'Peer', id: string, computeUnitsTotal: number, computeUnitsInDeal: number, computeUnitsInCapacityCommitment: number, offer: { __typename?: 'Offer', id: string }, provider: { __typename?: 'Provider', id: string, name: string } } | null };
+export type PeerQueryQuery = { __typename?: 'Query', peer?: { __typename?: 'Peer', id: string, computeUnitsTotal: number, computeUnitsInDeal: number, offer: { __typename?: 'Offer', id: string }, provider: { __typename?: 'Provider', id: string, name: string }, currentCapacityCommitment?: { __typename?: 'CapacityCommitment', activeUnitCount: number } | null } | null };
 
 export type ComputeUnitWithCcDataBasicFragment = { __typename?: 'ComputeUnit', id: string, workerId?: string | null, deal?: { __typename?: 'Deal', id: string } | null, peer: { __typename?: 'Peer', id: string, currentCapacityCommitment?: { __typename?: 'CapacityCommitment', id: string, collateralPerUnit: any, submittedProofsCount: number, startEpoch: any } | null, provider: { __typename?: 'Provider', id: string } } };
 
@@ -67,7 +67,9 @@ export const PeerQueryDocument = gql`
     }
     computeUnitsTotal
     computeUnitsInDeal
-    computeUnitsInCapacityCommitment
+    currentCapacityCommitment {
+      activeUnitCount
+    }
   }
 }
     `;

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.graphql
@@ -12,7 +12,9 @@ query PeerQuery(
     }
     computeUnitsTotal
     computeUnitsInDeal
-    computeUnitsInCapacityCommitment
+    currentCapacityCommitment {
+      activeUnitCount
+    }
   }
 }
 

--- a/ts-client/src/dealExplorerClient/serializers/schemes.ts
+++ b/ts-client/src/dealExplorerClient/serializers/schemes.ts
@@ -108,18 +108,15 @@ export function serializeProviderShort(
   } as ProviderShort;
 }
 
-// It composes only compute units with linked workerIds.
 export function serializeComputeUnits(
   fetchedComputeUnits: Array<ComputeUnitBasicFragment>,
 ): Array<ComputeUnit> {
   const res: Array<ComputeUnit> = [];
   for (const fetched of fetchedComputeUnits) {
-    if (fetched.workerId) {
-      res.push({
-        id: fetched.id,
-        workerId: fetched.workerId,
-      });
-    }
+    res.push({
+      id: fetched.id,
+      workerId: fetched.workerId ?? undefined,
+    });
   }
   return res;
 }


### PR DESCRIPTION
# Soft Breaking Change
- dealExplorerClient: it deprecates `[computeUnitsInCapacityCommitment](https://github.com/fluencelabs/deal/pull/323/commits/3d199c1f852e8c9db6e7a5b5eee46571cf175153)` used only in Network Explorer
- dealExplorerClient: also I resolved here empty Deals table for Peer view