### PR TITLE
fix: ux issue with providers and offers spam chain 441

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -8,8 +8,11 @@ type GraphNetwork @entity {
   coreContractAddress: String
   capacityContractAddress: String
   marketContractAddress: String
-  # TODO: remove when total field wil be added by developers.
+  # TODO: remove total counters when total counter field wil be added by developers.
   # https://github.com/graphprotocol/graph-node/issues/613
+  "Providers that register themselves in the network with setInfo() method."
+  providersRegisteredTotal: BigInt!
+  "@deprecated TODO: deprecate."
   providersTotal: BigInt!
   dealsTotal: BigInt!
   offersTotal: BigInt!

--- a/subgraph/src/mappings/market.ts
+++ b/subgraph/src/mappings/market.ts
@@ -53,7 +53,14 @@ export function handleProviderInfoUpdated(event: ProviderInfoUpdated): void {
     provider.approved = false;
   }
   provider.name = event.params.name;
-  provider.registered = true;
+
+  if (provider.registered == false) {
+    provider.registered = true;
+
+    let graphNetwork = createOrLoadGraphNetwork();
+    graphNetwork.providersRegisteredTotal = graphNetwork.providersRegisteredTotal.plus(UNO_BIG_INT);
+    graphNetwork.save()
+  }
   provider.save();
 }
 

--- a/subgraph/src/models.ts
+++ b/subgraph/src/models.ts
@@ -196,6 +196,7 @@ export function createOrLoadGraphNetwork(): GraphNetwork {
     graphNetwork = new GraphNetwork("1");
     graphNetwork.dealsTotal = ZERO_BIG_INT;
     graphNetwork.providersTotal = ZERO_BIG_INT;
+    graphNetwork.providersRegisteredTotal = ZERO_BIG_INT;
     graphNetwork.offersTotal = ZERO_BIG_INT;
     graphNetwork.tokensTotal = ZERO_BIG_INT;
     graphNetwork.effectorsTotal = ZERO_BIG_INT;

--- a/ts-client/src/dealCliClient/dealCliClient.ts
+++ b/ts-client/src/dealCliClient/dealCliClient.ts
@@ -20,8 +20,10 @@ export class DealCliClient {
 
   // @param indexerUrl: is optional - you force to replace indexer
   //  URL setting (by default it uses URL from network config mapping).
-  // @param serializationSettings: you can control how many fixed values after
-  //  floating point you want client to display.
+  // @param serializationSettings: you can control via additional formatters what
+  //  to do with token value after under-the-hood serialization:
+  //  after serialization of 1e+18 token value with 18 decimals to 1.0..0 ETH.
+  // E.g.: transform all 12.00000 -> to 12.0 (v) => v.replace(/\.0+$/, ".0").
   private _serializationSettings: SerializationSettings;
   constructor(
     network: ContractsENV,
@@ -32,10 +34,7 @@ export class DealCliClient {
     if (serializationSettings) {
       this._serializationSettings = serializationSettings;
     } else {
-      this._serializationSettings = {
-          parseNativeTokenToFixedDefault: 18,
-          parseTokenToFixedDefault: 3,
-        }
+      this._serializationSettings = {}
     }
   }
 

--- a/ts-client/src/dealCliClient/serializers/schemes.ts
+++ b/ts-client/src/dealCliClient/serializers/schemes.ts
@@ -31,8 +31,8 @@ export function serializeOfferDetail(offer: OfferDetailFragment, serializationSe
     // USDC.
     pricePerEpoch: tokenValueToRounded(
       offer.pricePerEpoch,
-      serializationSettings.parseTokenToFixedDefault,
       offer.paymentToken.decimals,
+      serializationSettings.paymentTokenValueAdditionalFormatter,
     ),
     effectors: serializeEffectors(offer.effectors),
     providerId: offer.provider.id,

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -278,7 +278,7 @@ export class DealExplorerClient {
       data: res,
       total: getTotalCounter(
         filters,
-        data.graphNetworks[0]?.providersTotal ?? 0,
+        data.graphNetworks[0]?.providersRegisteredTotal ?? 0,
       ),
     };
   }

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -458,7 +458,6 @@ export class DealExplorerClient {
         res.push(serializeOfferShort(offer, this._serializationSettings));
       }
     }
-    console.log(filtersSerialized, filtersSerialized);
     return {
       data: res,
       total: getTotalCounter(filters, data.graphNetworks[0]?.offersTotal ?? 0),

--- a/ts-client/src/dealExplorerClient/dealExplorerClient.ts
+++ b/ts-client/src/dealExplorerClient/dealExplorerClient.ts
@@ -153,10 +153,7 @@ export class DealExplorerClient {
     if (serializationSettings) {
       this._serializationSettings = serializationSettings;
     } else {
-      this._serializationSettings = {
-          parseNativeTokenToFixedDefault: 18,
-          parseTokenToFixedDefault: 3,
-        };
+      this._serializationSettings = {};
     }
     this._indexerClient = new IndexerClient(network);
     this._dealContractsClient = new DealClient(this._caller, network);
@@ -650,8 +647,8 @@ export class DealExplorerClient {
         // USDC.
         pricePerWorkerEpoch: tokenValueToRounded(
           deal.pricePerWorkerEpoch,
-          this._serializationSettings.parseTokenToFixedDefault,
           deal.paymentToken.decimals,
+          this._serializationSettings.paymentTokenValueAdditionalFormatter,
         ),
         maxWorkersPerProvider: deal.maxWorkersPerProvider,
         computeUnits: serializeComputeUnits(
@@ -968,7 +965,8 @@ export class DealExplorerClient {
       collateral: currentPeerCapacityCommitment
         ? tokenValueToRounded(
             currentPeerCapacityCommitment.collateralPerUnit,
-            this._serializationSettings.parseNativeTokenToFixedDefault,
+            Number(FLTToken.decimals),
+            this._serializationSettings.nativeTokenValueAdditionalFormatter,
           )
         : "0",
       successProofs: currentPeerCapacityCommitment

--- a/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
@@ -55,6 +55,7 @@ export type CapacityCommitment = {
   nextCCFailedEpoch: Scalars['BigInt']['output'];
   peer: Peer;
   provider: Provider;
+  /** This field represents Ratio [0, 1] only when it is divided by PRECISION constant of Core contract. */
   rewardDelegatorRate: Scalars['Int']['output'];
   rewardWithdrawn: Scalars['BigInt']['output'];
   snapshotEpoch: Scalars['BigInt']['output'];
@@ -1669,6 +1670,9 @@ export type GraphNetwork = {
   minRequiredProofsPerEpoch?: Maybe<Scalars['Int']['output']>;
   offersTotal: Scalars['BigInt']['output'];
   proofsTotal: Scalars['BigInt']['output'];
+  /** Providers that register themselves in the network with setInfo() method. */
+  providersRegisteredTotal: Scalars['BigInt']['output'];
+  /** @deprecated TODO: deprecate. */
   providersTotal: Scalars['BigInt']['output'];
   tokensTotal: Scalars['BigInt']['output'];
 };
@@ -1826,6 +1830,14 @@ export type GraphNetwork_Filter = {
   proofsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
   proofsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
   proofsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersRegisteredTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersRegisteredTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   providersTotal?: InputMaybe<Scalars['BigInt']['input']>;
   providersTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
   providersTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -1859,6 +1871,7 @@ export type GraphNetwork_OrderBy =
   | 'minRequiredProofsPerEpoch'
   | 'offersTotal'
   | 'proofsTotal'
+  | 'providersRegisteredTotal'
   | 'providersTotal'
   | 'tokensTotal';
 
@@ -2364,7 +2377,7 @@ export type Provider = {
   name: Scalars['String']['output'];
   offers?: Maybe<Array<Offer>>;
   peerCount: Scalars['Int']['output'];
-  /** Is provider registered in the network (if false - possible just mentioned). */
+  /** Is provider registered in the network (if false possibly it is only mentioned or global-whitelisted). */
   registered: Scalars['Boolean']['output'];
 };
 

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.generated.ts
@@ -15,7 +15,7 @@ export type ProvidersQueryQueryVariables = Types.Exact<{
 }>;
 
 
-export type ProvidersQueryQuery = { __typename?: 'Query', providers: Array<{ __typename?: 'Provider', id: string, name: string, createdAt: any, computeUnitsAvailable: number, computeUnitsTotal: number, approved: boolean, offers?: Array<{ __typename?: 'Offer', id: string, createdAt: any, pricePerEpoch: any, computeUnitsTotal?: number | null, computeUnitsAvailable?: number | null, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'OfferToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, provider: { __typename?: 'Provider', id: string }, peers?: Array<{ __typename?: 'Peer', id: string }> | null }> | null }>, graphNetworks: Array<{ __typename?: 'GraphNetwork', providersTotal: any }> };
+export type ProvidersQueryQuery = { __typename?: 'Query', providers: Array<{ __typename?: 'Provider', id: string, name: string, createdAt: any, computeUnitsAvailable: number, computeUnitsTotal: number, approved: boolean, offers?: Array<{ __typename?: 'Offer', id: string, createdAt: any, pricePerEpoch: any, computeUnitsTotal?: number | null, computeUnitsAvailable?: number | null, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'OfferToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, provider: { __typename?: 'Provider', id: string }, peers?: Array<{ __typename?: 'Peer', id: string }> | null }> | null }>, graphNetworks: Array<{ __typename?: 'GraphNetwork', providersRegisteredTotal: any }> };
 
 export type ProviderOfProvidersQueryFragment = { __typename?: 'Provider', id: string, name: string, createdAt: any, computeUnitsAvailable: number, computeUnitsTotal: number, approved: boolean, offers?: Array<{ __typename?: 'Offer', id: string, createdAt: any, pricePerEpoch: any, computeUnitsTotal?: number | null, computeUnitsAvailable?: number | null, paymentToken: { __typename?: 'Token', id: string, symbol: string, decimals: number }, effectors?: Array<{ __typename?: 'OfferToEffector', effector: { __typename?: 'Effector', id: string, description: string } }> | null, provider: { __typename?: 'Provider', id: string }, peers?: Array<{ __typename?: 'Peer', id: string }> | null }> | null };
 
@@ -94,7 +94,7 @@ export const ProvidersQueryDocument = gql`
     ...ProviderOfProvidersQuery
   }
   graphNetworks(first: 1) {
-    providersTotal
+    providersRegisteredTotal
   }
 }
     ${ProviderOfProvidersQueryFragmentDoc}`;

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.graphql
@@ -15,7 +15,7 @@ query ProvidersQuery(
     ...ProviderOfProvidersQuery
   }
   graphNetworks(first: 1) {
-    providersTotal
+    providersRegisteredTotal
   }
 }
 

--- a/ts-client/src/dealExplorerClient/serializers/logics.ts
+++ b/ts-client/src/dealExplorerClient/serializers/logics.ts
@@ -7,6 +7,7 @@ import {
   type SerializationSettings,
   tokenValueToRounded
 } from "../../utils/serializers.js";
+import { FLTToken } from "../constants.js";
 
 export function serializeProviderName(
   name: string,
@@ -57,11 +58,13 @@ export function serializeRewards(
     provider:
       tokenValueToRounded(
         providerReward,
-        serializationSettings.parseNativeTokenToFixedDefault,
+        Number(FLTToken.decimals),
+        serializationSettings.nativeTokenValueAdditionalFormatter,
         ),
     delegator: tokenValueToRounded(
       delegatorReward,
-      serializationSettings.parseNativeTokenToFixedDefault,
+      Number(FLTToken.decimals),
+      serializationSettings.nativeTokenValueAdditionalFormatter,
       ),
   }
 }

--- a/ts-client/src/dealExplorerClient/serializers/schemes.ts
+++ b/ts-client/src/dealExplorerClient/serializers/schemes.ts
@@ -59,8 +59,8 @@ export function serializeOfferShort(offer: BasicOfferFragment, serializationSett
     // USDC.
     pricePerEpoch: tokenValueToRounded(
       offer.pricePerEpoch,
-      serializationSettings.parseTokenToFixedDefault,
       offer.paymentToken.decimals,
+      serializationSettings.paymentTokenValueAdditionalFormatter,
     ),
     effectors: serializeEffectors(offer.effectors),
     providerId: offer.provider.id,
@@ -177,8 +177,8 @@ export function serializeDealsShort(
     // USDC.
     balance: tokenValueToRounded(
       freeBalance,
-      serializationSettings.parseTokenToFixedDefault,
       deal.paymentToken.decimals,
+      serializationSettings.paymentTokenValueAdditionalFormatter,
     ),
     status: fromRpcForDealShort.dealStatus
       ? fromRpcForDealShort.dealStatus
@@ -186,8 +186,8 @@ export function serializeDealsShort(
     // USDC.
     totalEarnings: tokenValueToRounded(
       totalEarnings,
-      serializationSettings.parseTokenToFixedDefault,
       deal.paymentToken.decimals,
+      serializationSettings.paymentTokenValueAdditionalFormatter,
     ),
     registeredWorkers: deal.registeredWorkersCurrentCount,
     matchedWorkers: deal.matchedWorkersCurrentCount,
@@ -277,26 +277,30 @@ export function serializeCapacityCommitmentDetail(
     // FLT.
     totalCollateral: tokenValueToRounded(
       totalCollateral,
-      serializationSettings.parseNativeTokenToFixedDefault,
+      Number(FLTToken.decimals),
+      serializationSettings.nativeTokenValueAdditionalFormatter,
     ),
     collateralToken: FLTToken,
     rewardDelegatorRate: rewardDelegatorRatePercentage,
     // FLT.
     rewardsUnlocked: tokenValueToRounded(
       _unlockedRewards,
-      serializationSettings.parseNativeTokenToFixedDefault,
+      Number(FLTToken.decimals),
+      serializationSettings.nativeTokenValueAdditionalFormatter,
     ),
     rewardsUnlockedDelegator: unclockedRewardsSerialized.delegator,
     rewardsUnlockedProvider: unclockedRewardsSerialized.provider,
     rewardsNotWithdrawn: tokenValueToRounded(
       _totalRewards,
-      serializationSettings.parseNativeTokenToFixedDefault,
+      Number(FLTToken.decimals),
+      serializationSettings.nativeTokenValueAdditionalFormatter,
     ),
     rewardsNotWithdrawnDelegator: notWithdrawnRewardsSerialized.delegator,
     rewardsNotWithdrawnProvider: notWithdrawnRewardsSerialized.provider,
     rewardsTotal: tokenValueToRounded(
       _totalRewards + BigInt(rewardWithdrawn),
-      serializationSettings.parseNativeTokenToFixedDefault,
+      Number(FLTToken.decimals),
+      serializationSettings.nativeTokenValueAdditionalFormatter,
     ),
     delegatorAddress:
       delegatorAddress == "0x0000000000000000000000000000000000000000"

--- a/ts-client/src/dealExplorerClient/utils.ts
+++ b/ts-client/src/dealExplorerClient/utils.ts
@@ -8,12 +8,26 @@ export const DEFAULT_ORDER_TYPE: OrderType = "desc";
 // Note, now it returns null when filters are not empty because for subgraph it
 //  is impossible to get counter with filtration.
 // Ref to https://github.com/graphprotocol/graph-node/issues/1309.
+// @param filters: filters that used to be sent to subgraph directly
+//  (thus, after serialization).
 export function getTotalCounter(
   // @ts-ignore
   filters: any,
   total: number,
 ): string | null {
-  if (Object.keys(filters).length) {
+  // onlyApproved == false filter should not be counted as actual filter for schemes:
+  // - OffersFilters,
+  // - ProvidersFilters,
+  //  because this false value is a default one. And default filter value should not be counted when we decide:
+  //  if we actually use filtration and, thus, we can not count total for the query.
+  // Note, this, behavior will be ignored when
+  //  counters will be implemented: https://github.com/graphprotocol/graph-node/issues/1309.
+  const filtersCopy = { ...filters };
+  if (filtersCopy.onlyApproved === false) {
+    delete filtersCopy.onlyApproved;
+  }
+
+  if (Object.keys(filtersCopy).length) {
     return null;
   }
   return total.toString();

--- a/ts-client/src/utils/serializers.ts
+++ b/ts-client/src/utils/serializers.ts
@@ -3,27 +3,23 @@ import { ethers } from "ethers";
 // Note, suffix Default because in the future we could check for minimal delta
 //  in contracts and parse by this dynamic value.
 export interface SerializationSettings {
-  parseNativeTokenToFixedDefault: number;
-  parseTokenToFixedDefault: number;
+  nativeTokenValueAdditionalFormatter?: (value: string) => string;
+  paymentTokenValueAdditionalFormatter?: (value: string) => string;
 }
 
 // Parse token value with its decimals to more human-readable format.
-// Note, first of all it parses value according to its decimals from contracts,
-//  after it parsed to supplied fixed format (in case it is 0.0000 it parsed to 0).
-// Note, toFixed should be equal to the minimal delta value in contracts that should be added (e.g. ).
-//  With this precision we sure that showed values are representative for the user.
-//  For stable coins with smth like 6 digits it seemed to use toFixed=2.
+// Additionally, it parses to fixed number after floating point.
 export function tokenValueToRounded(
   value: string | bigint,
-  toFixed: number = 3,
   decimals: number = 18,
+  customFormatter?: (value: string) => string,
 ) {
   const formatted = ethers.formatUnits(value, decimals);
-  const parsed = parseFloat(formatted).toFixed(toFixed);
-  if (parsed == "0." + "0".repeat(toFixed)) {
-    return "0"
+  const parsed = parseFloat(formatted).toFixed(decimals);
+  if (customFormatter) {
+    return customFormatter(parsed);
   }
-  return parsed
+  return parsed;
 }
 
 // Convert human-readable value to token value with its decimals (e.g. WEI in case of ETH-like tokens).


### PR DESCRIPTION
# ChangeLog
- subgraph: potential issue with provider counter resolved
- dealExplorerClient: add support for approved filtration behavior. To finally support https://github.com/fluencelabs/network-explorer/pull/22 (approved providers by default)
- dealExplorerClient & dealCliClient: refactor formatting of token values: add possibility to inject formatters (it does not seem to be breaking changes coz of this refactoring, because this deprecated feature was not used before). It closes CHAIN-433

# ToDO
- [x] test subgraph on kras fork
- [ ] update subgraph