### PR TITLE
fix: subgraph after offer updated [chain 442]

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,5 +1,5 @@
-# Comments relates to Figma screen names.
-# Names according to Figma. Suffix according to api list, details
+# In the scheme below used behaviour where deleted entity marked as deleted=True instead of actual deletion (in contrast as in contract).
+# Thus, please refer to the field when querying the data.
 
 type GraphNetwork @entity {
   "ID is set to 1"
@@ -10,9 +10,10 @@ type GraphNetwork @entity {
   marketContractAddress: String
   # TODO: remove total counters when total counter field wil be added by developers.
   # https://github.com/graphprotocol/graph-node/issues/613
+  # Note that total counter for not deleted entities.
   "Providers that register themselves in the network with setInfo() method."
   providersRegisteredTotal: BigInt!
-  "@deprecated TODO: deprecate."
+  "@deprecated TODO: deprecate because it is not used. changed to providersRegisteredTotal used."
   providersTotal: BigInt!
   dealsTotal: BigInt!
   offersTotal: BigInt!
@@ -46,6 +47,7 @@ type Provider @entity {
   offers: [Offer!] @derivedFrom(field: "provider")
 
   # Add Statistics below.
+  "It depends on if CU in deal or not."
   computeUnitsAvailable: Int! # Sum of all available compute units in the offer (not in the deals).
   computeUnitsTotal: Int! # Sum of all compute units registered in the offer. TODO: when CU deleted?
   peerCount: Int!
@@ -70,6 +72,7 @@ type Offer @entity {
   effectors: [OfferToEffector!] @derivedFrom(field: "offer")
 
   # Add Statistics below.
+  "It depends on if CU in deal or not."
   computeUnitsAvailable: Int # Sum of all available compute units in the offer (not in the deals).
   computeUnitsTotal: Int # Sum of all compute units registered in the offer. TODO: when CU deleted?
   # Add helpers fields to support some queries below.
@@ -138,6 +141,7 @@ type ComputeUnit @entity {
   peer: Peer!
   "In order to simplify relation for query."
   provider: Provider!
+  deleted: Boolean!
 
   deal: Deal
   workerId: String

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,5 +1,7 @@
-# In the scheme below used behaviour where deleted entity marked as deleted=True instead of actual deletion (in contrast as in contract).
-# Thus, please refer to the field when querying the data.
+"""
+In the scheme below used behaviour where deleted entity marked as deleted=True instead of actual deletion (in contrast as in contract).
+Thus, please refer to the field when querying the data.
+"""
 
 type GraphNetwork @entity {
   "ID is set to 1"

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,7 +1,7 @@
 """
 In the scheme below we used behaviour where deleted entity marked as deleted=True instead of actual deletion (in contrast as in contract).
-Thus, please refer to the field when querying the data.
-Note, all deleted entities are out of scope for presented counters.
+Thus, please refer to the deleted field when querying the data.
+Note, all deleted entities are out of scope for presented counters in all models.
 """
 
 type GraphNetwork @entity {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,6 +1,7 @@
 """
-In the scheme below used behaviour where deleted entity marked as deleted=True instead of actual deletion (in contrast as in contract).
+In the scheme below we used behaviour where deleted entity marked as deleted=True instead of actual deletion (in contrast as in contract).
 Thus, please refer to the field when querying the data.
+Note, all deleted entities are out of scope for presented counters.
 """
 
 type GraphNetwork @entity {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -112,6 +112,7 @@ type Peer @entity {
   id: ID!
   offer: Offer!
   provider: Provider!
+  deleted: Boolean!
   computeUnits: [ComputeUnit!] @derivedFrom(field: "peer")
 
   currentCapacityCommitment: CapacityCommitment

--- a/subgraph/src/mappings/capacity.ts
+++ b/subgraph/src/mappings/capacity.ts
@@ -8,7 +8,7 @@ import {
   createOrLoadProvider,
   UNO_BIG_INT,
   ZERO_ADDRESS,
-  ZERO_BIG_INT
+  ZERO_BIG_INT,
 } from "../models";
 import {
   CapacityCommitment,
@@ -89,7 +89,10 @@ export function handleCommitmentCreated(event: CommitmentCreated): void {
   for (let i = 0; i < loadedComputeUnitsLength; i++) {
     // We rely on contract logic that it is not possible to emit event with not existing CUs.
     //  Also, we rely that previously we save computeUnits successfully in prev. handler of computeUnitCreated.
-    createOrLoadCapacityCommitmentToComputeUnit(commitment.id, loadedComputeUnits[i].id);
+    createOrLoadCapacityCommitmentToComputeUnit(
+      commitment.id,
+      loadedComputeUnits[i].id,
+    );
   }
   commitment.nextAdditionalActiveUnitCount = 0;
   commitment.snapshotEpoch = ZERO_BIG_INT;
@@ -233,7 +236,11 @@ export function handleCommitmentStatsUpdated(
     BigInt.fromI32(graphNetwork.initTimestamp),
     BigInt.fromI32(graphNetwork.coreEpochDuration),
   );
-  const epochStatistic = createOrLoadEpochStatistic(event.block.timestamp, currentEpoch, event.block.number)
+  const epochStatistic = createOrLoadEpochStatistic(
+    event.block.timestamp,
+    currentEpoch,
+    event.block.number,
+  );
 
   let peer = Peer.load(commitment.peer) as Peer;
   peer.currentCCNextCCFailedEpoch = commitment.nextCCFailedEpoch;
@@ -258,7 +265,7 @@ export function handleCommitmentStatsUpdated(
   capacityCommitmentStatsPerEpoch.save();
 }
 
-export function handleUnitActivated(event: UnitActivated): void { }
+export function handleUnitActivated(event: UnitActivated): void {}
 
 // Handle that Compute Unit moved from CC to Deal with arguments of CC and CU.
 // Currently, it updates only capacityCommitmentStatsPerEpoch.
@@ -273,7 +280,11 @@ export function handleUnitDeactivated(event: UnitDeactivated): void {
   const capacityCommitment = CapacityCommitment.load(
     event.params.commitmentId.toHexString(),
   ) as CapacityCommitment;
-  const epochStatistic = createOrLoadEpochStatistic(event.block.timestamp, currentEpoch, event.block.number);
+  const epochStatistic = createOrLoadEpochStatistic(
+    event.block.timestamp,
+    currentEpoch,
+    event.block.number,
+  );
   let capacityCommitmentStatsPerEpoch =
     createOrLoadCapacityCommitmentStatsPerEpoch(
       capacityCommitment.id,
@@ -289,17 +300,21 @@ export function handleUnitDeactivated(event: UnitDeactivated): void {
 
   // When compute unit added to Deal we also should calculate if we need to
   //  decrease counter named computeUnitsWithMinRequiredProofsSubmittedCounter.
-  if (computeUnitPerEpochStat.submittedProofsCount >= graphNetwork.minRequiredProofsPerEpoch) {
+  if (
+    computeUnitPerEpochStat.submittedProofsCount >=
+    graphNetwork.minRequiredProofsPerEpoch
+  ) {
     // Decrease computeUnitsWithMinRequiredProofsSubmittedCounter.
     capacityCommitmentStatsPerEpoch.computeUnitsWithMinRequiredProofsSubmittedCounter =
-      capacityCommitmentStatsPerEpoch.computeUnitsWithMinRequiredProofsSubmittedCounter - 1;
+      capacityCommitmentStatsPerEpoch.computeUnitsWithMinRequiredProofsSubmittedCounter -
+      1;
     capacityCommitmentStatsPerEpoch.save();
   }
 }
 
 export function handleProofSubmitted(event: ProofSubmitted): void {
   let proofSubmitted = new SubmittedProof(event.transaction.hash.toHexString());
-  const blockTimestamp = event.block.timestamp
+  const blockTimestamp = event.block.timestamp;
   let capacityCommitment = CapacityCommitment.load(
     event.params.commitmentId.toHexString(),
   ) as CapacityCommitment;
@@ -313,7 +328,11 @@ export function handleProofSubmitted(event: ProofSubmitted): void {
     BigInt.fromI32(graphNetwork.initTimestamp),
     BigInt.fromI32(graphNetwork.coreEpochDuration),
   );
-  const epochStatistic = createOrLoadEpochStatistic(blockTimestamp, currentEpoch, event.block.number)
+  const epochStatistic = createOrLoadEpochStatistic(
+    blockTimestamp,
+    currentEpoch,
+    event.block.number,
+  );
   let capacityCommitmentStatsPerEpoch =
     createOrLoadCapacityCommitmentStatsPerEpoch(
       capacityCommitment.id,

--- a/subgraph/src/mappings/core.ts
+++ b/subgraph/src/mappings/core.ts
@@ -1,7 +1,7 @@
 import {
   createOrLoadEpochStatistic,
   createOrLoadGraphNetwork,
-  createOrLoadProvider
+  createOrLoadProvider,
 } from "../models";
 import {
   Initialized,
@@ -14,7 +14,7 @@ import {
   getEpochDuration,
   getInitTimestamp,
   getMinRequiredProofsPerEpoch,
-  getPrecision
+  getPrecision,
 } from "../contracts";
 import { formatAddress } from "./utils";
 import { log, BigInt } from "@graphprotocol/graph-ts/index";
@@ -39,7 +39,10 @@ export function handleInitialized(event: Initialized): void {
 export function handleWhitelistAccessGranted(
   event: WhitelistAccessGranted,
 ): void {
-  let provider = createOrLoadProvider(formatAddress(event.params.account), event.block.timestamp);
+  let provider = createOrLoadProvider(
+    formatAddress(event.params.account),
+    event.block.timestamp,
+  );
   provider.approved = true;
   provider.save();
 }
@@ -47,7 +50,10 @@ export function handleWhitelistAccessGranted(
 export function handleWhitelistAccessRevoked(
   event: WhitelistAccessRevoked,
 ): void {
-  let provider = createOrLoadProvider(formatAddress(event.params.account), event.block.timestamp);
+  let provider = createOrLoadProvider(
+    formatAddress(event.params.account),
+    event.block.timestamp,
+  );
   provider.approved = false;
   provider.save();
 }
@@ -59,10 +65,11 @@ export function handleNewBlock(block: ethereum.Block): void {
   let initTimestamp = graphNetwork.initTimestamp;
   let coreEpochDuration = graphNetwork.coreEpochDuration;
   const blockNumber = block.number;
-  if (!initTimestamp || !coreEpochDuration)  {
+  if (!initTimestamp || !coreEpochDuration) {
     log.warning(
-      `[handleNewBlock] This handler should be called after core contract inited! Otherwise it will have wrong data. Core is not inited on block number ${blockNumber}, thus, pass.`
-    , [])
+      `[handleNewBlock] This handler should be called after core contract inited! Otherwise it will have wrong data. Core is not inited on block number ${blockNumber}, thus, pass.`,
+      [],
+    );
     return;
   }
 
@@ -73,7 +80,11 @@ export function handleNewBlock(block: ethereum.Block): void {
     BigInt.fromI32(coreEpochDuration),
   );
 
-  let epochStatistic = createOrLoadEpochStatistic(blockTimestamp, currentEpoch, blockNumber);
+  let epochStatistic = createOrLoadEpochStatistic(
+    blockTimestamp,
+    currentEpoch,
+    blockNumber,
+  );
   if (epochStatistic.endBlock < blockNumber) {
     epochStatistic.endBlock = blockNumber;
     epochStatistic.endTimestamp = blockTimestamp;

--- a/subgraph/src/mappings/deal-factory.ts
+++ b/subgraph/src/mappings/deal-factory.ts
@@ -1,32 +1,28 @@
 // File should be writen after `npm run compile` is run or you will encounter syntax and import errors.
 // Note: handlers named as in the contract methods
 
-import {
-  DealCreated,
-} from "../../generated/DealFactory/DealFactory";
+import { DealCreated } from "../../generated/DealFactory/DealFactory";
 import {
   createOrLoadDealEffector,
   createOrLoadDealToProvidersAccess,
-  createOrLoadGraphNetwork, createOrLoadToken,
+  createOrLoadGraphNetwork,
+  createOrLoadToken,
   createOrLoadProvider,
   UNO_BIG_INT,
   ZERO_BIG_INT,
 } from "../models";
 
 import { log } from "@graphprotocol/graph-ts";
-import {
-  Deal,
-} from "../../generated/schema";
+import { Deal } from "../../generated/schema";
 import { Deal as DealTemplate } from "../../generated/templates";
 import { AppCID, formatAddress, getEffectorCID, parseEffectors } from "./utils";
 
-
 // ---- Factory Events ----
 export function handleDealCreated(event: DealCreated): void {
-  log.info("[handleDealCreated] Create new Deal with address: {} with owner: {}", [
-    event.params.deal.toHexString(),
-    event.params.owner.toHexString()
-  ]);
+  log.info(
+    "[handleDealCreated] Create new Deal with address: {} with owner: {}",
+    [event.params.deal.toHexString(), event.params.owner.toHexString()],
+  );
   const dealAddress = formatAddress(event.params.deal);
 
   const deal = new Deal(dealAddress);
@@ -48,9 +44,12 @@ export function handleDealCreated(event: DealCreated): void {
 
   // Perform provider access lists (whitelist, blacklist or non).
   deal.providersAccessType = event.params.providersAccessType_;
-  for (let i=0; i < event.params.providersAccessList_.length; i++) {
+  for (let i = 0; i < event.params.providersAccessList_.length; i++) {
     const providerAddress = formatAddress(event.params.providersAccessList_[i]);
-    const provider = createOrLoadProvider(providerAddress, event.block.timestamp);
+    const provider = createOrLoadProvider(
+      providerAddress,
+      event.block.timestamp,
+    );
     createOrLoadDealToProvidersAccess(deal.id, provider.id);
   }
   deal.save();

--- a/subgraph/src/mappings/deal.ts
+++ b/subgraph/src/mappings/deal.ts
@@ -1,4 +1,4 @@
-import {AppCID, formatAddress, getEffectorCID} from "./utils";
+import { AppCID, formatAddress, getEffectorCID } from "./utils";
 import {
   AppCIDChanged,
   ComputeUnitJoined,
@@ -6,14 +6,16 @@ import {
   MaxPaidEpochUpdated,
   Withdrawn,
   WorkerIdUpdated,
-  ComputeUnitRemoved, ProviderAddedToAccessList, ProviderRemovedFromAccessList,
+  ComputeUnitRemoved,
+  ProviderAddedToAccessList,
+  ProviderRemovedFromAccessList,
 } from "../../generated/Market/Deal";
 import { ComputeUnit, Deal } from "../../generated/schema";
 import {
   createOrLoadDealToProvidersAccess,
-  createOrLoadProvider
+  createOrLoadProvider,
 } from "../models";
-import {store} from "@graphprotocol/graph-ts";
+import { store } from "@graphprotocol/graph-ts";
 
 export function handleDeposited(event: Deposited): void {
   let deal = Deal.load(formatAddress(event.address)) as Deal;
@@ -80,15 +82,25 @@ export function handleWorkerIdUpdated(event: WorkerIdUpdated): void {
   }
 }
 
-export function handleProviderAddedToAccessList(event: ProviderAddedToAccessList): void {
+export function handleProviderAddedToAccessList(
+  event: ProviderAddedToAccessList,
+): void {
   const deal = Deal.load(formatAddress(event.address)) as Deal;
-  const provider = createOrLoadProvider(formatAddress(event.params.provider), event.block.timestamp);
+  const provider = createOrLoadProvider(
+    formatAddress(event.params.provider),
+    event.block.timestamp,
+  );
   createOrLoadDealToProvidersAccess(deal.id, provider.id);
 }
 
-export function handleProviderRemovedFromAccessList(event: ProviderRemovedFromAccessList): void {
+export function handleProviderRemovedFromAccessList(
+  event: ProviderRemovedFromAccessList,
+): void {
   const deal = Deal.load(formatAddress(event.address)) as Deal;
-  const provider = createOrLoadProvider(formatAddress(event.params.provider), event.block.timestamp);
+  const provider = createOrLoadProvider(
+    formatAddress(event.params.provider),
+    event.block.timestamp,
+  );
   const entity = createOrLoadDealToProvidersAccess(deal.id, provider.id);
   store.remove("OfferToEffector", entity.id);
 }

--- a/subgraph/src/mappings/market.ts
+++ b/subgraph/src/mappings/market.ts
@@ -293,7 +293,7 @@ export function handleComputeUnitRemoved(
   const offer = Offer.load(peer.offer) as Offer;
   const provider = createOrLoadProvider(offer.provider, event.block.timestamp);
 
-  const computeUnit = ComputeUnit.load(event.params.unitId.toHexString());
+  const computeUnit = ComputeUnit.load(event.params.unitId.toHexString()) as ComputeUnit;
   computeUnit.deleted = true;
   computeUnit.save();
 
@@ -303,7 +303,7 @@ export function handleComputeUnitRemoved(
 
 // @param increaseSign: use +1 or -1 to decrease.
 function _updateComputeUnitStats(
-  increaseSign: number,
+  increaseSign: i32,
   peer: Peer,
   offer: Offer,
   provider: Provider,

--- a/subgraph/src/mappings/utils.ts
+++ b/subgraph/src/mappings/utils.ts
@@ -1,6 +1,6 @@
 import { Bytes, ethereum, log } from "@graphprotocol/graph-ts/index";
 import { createOrLoadEffector } from "../models";
-import {Address} from "@graphprotocol/graph-ts";
+import { Address } from "@graphprotocol/graph-ts";
 
 export class AppCID extends ethereum.Tuple {
   get prefixes(): Bytes {
@@ -36,7 +36,9 @@ export function parseEffectors(effectors: Array<AppCID>): Array<string> {
  */
 export function getEffectorCID(effectorTuple: AppCID): string {
   // Also rm Ox prefix.
-  const cid = effectorTuple.prefixes.toHexString().slice(2) + effectorTuple.hash.toHexString().slice(2);
+  const cid =
+    effectorTuple.prefixes.toHexString().slice(2) +
+    effectorTuple.hash.toHexString().slice(2);
   log.info("[getEffectorCID] Extract CID from effector: {}", [cid]);
   return cid;
 }

--- a/subgraph/src/models.ts
+++ b/subgraph/src/models.ts
@@ -57,7 +57,7 @@ export function createOrLoadProvider(
     // Upd stats below.
     let graphNetwork = createOrLoadGraphNetwork();
     graphNetwork.providersTotal = graphNetwork.providersTotal.plus(UNO_BIG_INT);
-    graphNetwork.save()
+    graphNetwork.save();
   }
   return entity as Provider;
 }
@@ -299,8 +299,12 @@ export function createOrLoadComputeUnitPerEpochStat(
   return entity as ComputeUnitPerEpochStat;
 }
 
-export function createOrLoadEpochStatistic(timestamp: BigInt, currentEpoch: BigInt, currentBlock: BigInt): EpochStatistic {
-  const currentEpochId = currentEpoch.toString()
+export function createOrLoadEpochStatistic(
+  timestamp: BigInt,
+  currentEpoch: BigInt,
+  currentBlock: BigInt,
+): EpochStatistic {
+  const currentEpochId = currentEpoch.toString();
   let entity = EpochStatistic.load(currentEpochId);
 
   if (entity == null) {

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -91,6 +91,7 @@ dataSources:
           handler: handleComputeUnitRemoved
         - event: PeerRemoved(indexed bytes32,indexed bytes32)
           handler: handlePeerRemoved
+          # TODO: support remove Offer.
       file: ./src/mappings/market.ts
   - kind: ethereum/contract
     name: DealFactory

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -1,6 +1,6 @@
 specVersion: 0.0.5
-description: TODO
-repository: https://TODO
+description: FluenceLabs Deal System Subgraph Scheme
+repository: https://github.com/fluencelabs/deal
 schema:
   file: ./schema.graphql
 dataSources:

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -87,6 +87,10 @@ dataSources:
           handler: handleComputeUnitAddedToDeal
         - event: ComputeUnitRemovedFromDeal(indexed bytes32,address,bytes32)
           handler: handleComputeUnitRemovedFromDeal
+        - event: ComputeUnitRemoved(indexed bytes32,indexed bytes32)
+          handler: handleComputeUnitRemoved
+        - event: PeerRemoved(indexed bytes32,indexed bytes32)
+          handler: handlePeerRemoved
       file: ./src/mappings/market.ts
   - kind: ethereum/contract
     name: DealFactory

--- a/ts-client/src/dealCliClient/dealCliClient.ts
+++ b/ts-client/src/dealCliClient/dealCliClient.ts
@@ -4,7 +4,6 @@ import type { DealByProvider, OfferDetail } from "./types/schemes.js";
 import { serializeOfferDetail } from "./serializers/schemes.js";
 import type { SerializationSettings } from "../utils/serializers.js";
 
-
 /*
  * @dev This client represents endpoints to access desirable indexer data in REST
  * @dev  manner from POV of Fluence CLI.
@@ -34,7 +33,7 @@ export class DealCliClient {
     if (serializationSettings) {
       this._serializationSettings = serializationSettings;
     } else {
-      this._serializationSettings = {}
+      this._serializationSettings = {};
     }
   }
 
@@ -47,23 +46,23 @@ export class DealCliClient {
     };
     const data = await this.indexerClient.getOffer(options);
     if (data.offer) {
-      return serializeOfferDetail(data.offer, this._serializationSettings)
+      return serializeOfferDetail(data.offer, this._serializationSettings);
     }
-    return null
+    return null;
   }
 
   async getDealsByProvider(providerId: string): Promise<Array<DealByProvider>> {
-    const data = await this.indexerClient.getDeals(
-      {
-        filters: {
-          addedComputeUnits_: { provider: providerId.toLowerCase() }
-        }
-      }
-    )
-    return data.deals.map((deal) => {
-      return {
-        id: deal.id,
-      }
-    }) || []
+    const data = await this.indexerClient.getDeals({
+      filters: {
+        addedComputeUnits_: { provider: providerId.toLowerCase() },
+      },
+    });
+    return (
+      data.deals.map((deal) => {
+        return {
+          id: deal.id,
+        };
+      }) || []
+    );
   }
 }

--- a/ts-client/src/dealCliClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealCliClient/indexerClient/generated.types.ts
@@ -55,6 +55,7 @@ export type CapacityCommitment = {
   nextCCFailedEpoch: Scalars['BigInt']['output'];
   peer: Peer;
   provider: Provider;
+  /** This field represents Ratio [0, 1] only when it is divided by PRECISION constant of Core contract. */
   rewardDelegatorRate: Scalars['Int']['output'];
   rewardWithdrawn: Scalars['BigInt']['output'];
   snapshotEpoch: Scalars['BigInt']['output'];
@@ -98,13 +99,13 @@ export type CapacityCommitmentSubmittedProofsArgs = {
 export type CapacityCommitmentStatsPerEpoch = {
   __typename?: 'CapacityCommitmentStatsPerEpoch';
   activeUnitCount: Scalars['Int']['output'];
-  blockNumberEnd: Scalars['BigInt']['output'];
-  blockNumberStart: Scalars['BigInt']['output'];
   capacityCommitment: CapacityCommitment;
   /** Should be update after ComputeUnitPerEpochStat.submittedProofsCount reached min proofs border. */
   computeUnitsWithMinRequiredProofsSubmittedCounter: Scalars['Int']['output'];
   currentCCNextCCFailedEpoch: Scalars['BigInt']['output'];
+  /** Additional field to support ordering by epoch. */
   epoch: Scalars['BigInt']['output'];
+  epochStatistic: EpochStatistic;
   exitedUnitCount: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   nextAdditionalActiveUnitCount: Scalars['Int']['output'];
@@ -135,22 +136,6 @@ export type CapacityCommitmentStatsPerEpoch_Filter = {
   activeUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
   activeUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   and?: InputMaybe<Array<InputMaybe<CapacityCommitmentStatsPerEpoch_Filter>>>;
-  blockNumberEnd?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  blockNumberEnd_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_not?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  blockNumberStart?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  blockNumberStart_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_not?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   capacityCommitment?: InputMaybe<Scalars['String']['input']>;
   capacityCommitment_?: InputMaybe<CapacityCommitment_Filter>;
   capacityCommitment_contains?: InputMaybe<Scalars['String']['input']>;
@@ -189,6 +174,27 @@ export type CapacityCommitmentStatsPerEpoch_Filter = {
   currentCCNextCCFailedEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
   currentCCNextCCFailedEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   epoch?: InputMaybe<Scalars['BigInt']['input']>;
+  epochStatistic?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_?: InputMaybe<EpochStatistic_Filter>;
+  epochStatistic_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_lt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_lte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   epoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
   epoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
   epoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -242,8 +248,6 @@ export type CapacityCommitmentStatsPerEpoch_Filter = {
 
 export type CapacityCommitmentStatsPerEpoch_OrderBy =
   | 'activeUnitCount'
-  | 'blockNumberEnd'
-  | 'blockNumberStart'
   | 'capacityCommitment'
   | 'capacityCommitment__activeUnitCount'
   | 'capacityCommitment__collateralPerUnit'
@@ -269,6 +273,12 @@ export type CapacityCommitmentStatsPerEpoch_OrderBy =
   | 'computeUnitsWithMinRequiredProofsSubmittedCounter'
   | 'currentCCNextCCFailedEpoch'
   | 'epoch'
+  | 'epochStatistic'
+  | 'epochStatistic__endBlock'
+  | 'epochStatistic__endTimestamp'
+  | 'epochStatistic__id'
+  | 'epochStatistic__startBlock'
+  | 'epochStatistic__startTimestamp'
   | 'exitedUnitCount'
   | 'id'
   | 'nextAdditionalActiveUnitCount'
@@ -373,6 +383,7 @@ export type CapacityCommitmentToComputeUnit_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
@@ -622,6 +633,7 @@ export type CapacityCommitment_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'
@@ -647,6 +659,7 @@ export type ComputeUnit = {
   __typename?: 'ComputeUnit';
   createdAt: Scalars['BigInt']['output'];
   deal?: Maybe<Deal>;
+  deleted: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   peer: Peer;
   /** In order to simplify relation for query. */
@@ -670,7 +683,7 @@ export type ComputeUnitPerEpochStat = {
   __typename?: 'ComputeUnitPerEpochStat';
   capacityCommitment?: Maybe<CapacityCommitment>;
   computeUnit: ComputeUnit;
-  epoch: Scalars['BigInt']['output'];
+  epochStatistic: EpochStatistic;
   id: Scalars['ID']['output'];
   submittedProofsCount: Scalars['Int']['output'];
 };
@@ -721,14 +734,27 @@ export type ComputeUnitPerEpochStat_Filter = {
   computeUnit_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   computeUnit_starts_with?: InputMaybe<Scalars['String']['input']>;
   computeUnit_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  epoch?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  epoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_not?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  epochStatistic?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_?: InputMaybe<EpochStatistic_Filter>;
+  epochStatistic_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_lt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_lte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -773,10 +799,16 @@ export type ComputeUnitPerEpochStat_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
-  | 'epoch'
+  | 'epochStatistic'
+  | 'epochStatistic__endBlock'
+  | 'epochStatistic__endTimestamp'
+  | 'epochStatistic__id'
+  | 'epochStatistic__startBlock'
+  | 'epochStatistic__startTimestamp'
   | 'id'
   | 'submittedProofsCount';
 
@@ -813,6 +845,10 @@ export type ComputeUnit_Filter = {
   deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   deal_starts_with?: InputMaybe<Scalars['String']['input']>;
   deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  deleted_not?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -912,6 +948,7 @@ export type ComputeUnit_OrderBy =
   | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
+  | 'deleted'
   | 'id'
   | 'peer'
   | 'peer__computeUnitsInDeal'
@@ -919,6 +956,7 @@ export type ComputeUnit_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'
@@ -1204,6 +1242,7 @@ export type DealToJoinedOfferPeer_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals';
 
@@ -1305,6 +1344,7 @@ export type DealToPeer_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals';
 
@@ -1652,6 +1692,71 @@ export type Effector_OrderBy =
   | 'id'
   | 'offers';
 
+/** This model is designed to store epoch related information. Note, that in other models it is more efficient to store epoch as bigint rather than relation to that model (with relation you could complicate your queries by epoch, or you will need to store additional epoch field anyway). */
+export type EpochStatistic = {
+  __typename?: 'EpochStatistic';
+  endBlock: Scalars['BigInt']['output'];
+  endTimestamp: Scalars['BigInt']['output'];
+  /** Epoch number. Note, that for current epoch right boarder is approximate. */
+  id: Scalars['ID']['output'];
+  startBlock: Scalars['BigInt']['output'];
+  startTimestamp: Scalars['BigInt']['output'];
+};
+
+export type EpochStatistic_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EpochStatistic_Filter>>>;
+  endBlock?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endBlock_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_not?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endTimestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endTimestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<EpochStatistic_Filter>>>;
+  startBlock?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startBlock_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_not?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startTimestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startTimestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+};
+
+export type EpochStatistic_OrderBy =
+  | 'endBlock'
+  | 'endTimestamp'
+  | 'id'
+  | 'startBlock'
+  | 'startTimestamp';
+
 export type GraphNetwork = {
   __typename?: 'GraphNetwork';
   capacityCommitmentsTotal: Scalars['BigInt']['output'];
@@ -1659,6 +1764,7 @@ export type GraphNetwork = {
   capacityMaxFailedRatio?: Maybe<Scalars['Int']['output']>;
   coreContractAddress?: Maybe<Scalars['String']['output']>;
   coreEpochDuration?: Maybe<Scalars['Int']['output']>;
+  corePrecision?: Maybe<Scalars['Int']['output']>;
   dealsTotal: Scalars['BigInt']['output'];
   effectorsTotal: Scalars['BigInt']['output'];
   /** ID is set to 1 */
@@ -1668,6 +1774,9 @@ export type GraphNetwork = {
   minRequiredProofsPerEpoch?: Maybe<Scalars['Int']['output']>;
   offersTotal: Scalars['BigInt']['output'];
   proofsTotal: Scalars['BigInt']['output'];
+  /** Providers that register themselves in the network with setInfo() method. */
+  providersRegisteredTotal: Scalars['BigInt']['output'];
+  /** @deprecated TODO: deprecate because it is not used. changed to providersRegisteredTotal used. */
   providersTotal: Scalars['BigInt']['output'];
   tokensTotal: Scalars['BigInt']['output'];
 };
@@ -1740,6 +1849,14 @@ export type GraphNetwork_Filter = {
   coreEpochDuration_lte?: InputMaybe<Scalars['Int']['input']>;
   coreEpochDuration_not?: InputMaybe<Scalars['Int']['input']>;
   coreEpochDuration_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  corePrecision?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_gt?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_gte?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  corePrecision_lt?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_lte?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_not?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   dealsTotal?: InputMaybe<Scalars['BigInt']['input']>;
   dealsTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
   dealsTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -1817,6 +1934,14 @@ export type GraphNetwork_Filter = {
   proofsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
   proofsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
   proofsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersRegisteredTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersRegisteredTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   providersTotal?: InputMaybe<Scalars['BigInt']['input']>;
   providersTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
   providersTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -1841,6 +1966,7 @@ export type GraphNetwork_OrderBy =
   | 'capacityMaxFailedRatio'
   | 'coreContractAddress'
   | 'coreEpochDuration'
+  | 'corePrecision'
   | 'dealsTotal'
   | 'effectorsTotal'
   | 'id'
@@ -1849,11 +1975,13 @@ export type GraphNetwork_OrderBy =
   | 'minRequiredProofsPerEpoch'
   | 'offersTotal'
   | 'proofsTotal'
+  | 'providersRegisteredTotal'
   | 'providersTotal'
   | 'tokensTotal';
 
 export type Offer = {
   __typename?: 'Offer';
+  /** It depends on if CU in deal or not. */
   computeUnitsAvailable?: Maybe<Scalars['Int']['output']>;
   computeUnitsTotal?: Maybe<Scalars['Int']['output']>;
   createdAt: Scalars['BigInt']['output'];
@@ -2134,6 +2262,7 @@ export type Peer = {
   currentCCEndEpoch?: Maybe<Scalars['BigInt']['output']>;
   currentCCNextCCFailedEpoch?: Maybe<Scalars['BigInt']['output']>;
   currentCapacityCommitment?: Maybe<CapacityCommitment>;
+  deleted: Scalars['Boolean']['output'];
   /** ref to peerId in contract. */
   id: Scalars['ID']['output'];
   isAnyJoinedDeals: Scalars['Boolean']['output'];
@@ -2236,6 +2365,10 @@ export type Peer_Filter = {
   currentCapacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   currentCapacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
   currentCapacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  deleted_not?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -2324,6 +2457,7 @@ export type Peer_OrderBy =
   | 'currentCapacityCommitment__submittedProofsCount'
   | 'currentCapacityCommitment__totalCollateral'
   | 'currentCapacityCommitment__totalFailCount'
+  | 'deleted'
   | 'id'
   | 'isAnyJoinedDeals'
   | 'joinedDeals'
@@ -2347,6 +2481,7 @@ export type Peer_OrderBy =
 export type Provider = {
   __typename?: 'Provider';
   approved: Scalars['Boolean']['output'];
+  /** It depends on if CU in deal or not. */
   computeUnitsAvailable: Scalars['Int']['output'];
   computeUnitsTotal: Scalars['Int']['output'];
   createdAt: Scalars['BigInt']['output'];
@@ -2354,7 +2489,7 @@ export type Provider = {
   name: Scalars['String']['output'];
   offers?: Maybe<Array<Offer>>;
   peerCount: Scalars['Int']['output'];
-  /** Is provider registered in the network (if false - possible just mentioned). */
+  /** Is provider registered in the network (if false possibly it is only mentioned or global-whitelisted). */
   registered: Scalars['Boolean']['output'];
 };
 
@@ -2480,6 +2615,8 @@ export type Query = {
   deals: Array<Deal>;
   effector?: Maybe<Effector>;
   effectors: Array<Effector>;
+  epochStatistic?: Maybe<EpochStatistic>;
+  epochStatistics: Array<EpochStatistic>;
   graphNetwork?: Maybe<GraphNetwork>;
   graphNetworks: Array<GraphNetwork>;
   offer?: Maybe<Offer>;
@@ -2697,6 +2834,24 @@ export type QueryEffectorsArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Effector_Filter>;
+};
+
+
+export type QueryEpochStatisticArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryEpochStatisticsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<EpochStatistic_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<EpochStatistic_Filter>;
 };
 
 
@@ -2989,8 +3144,6 @@ export type SubmittedProof_OrderBy =
   | 'capacityCommitment'
   | 'capacityCommitmentStatsPerEpoch'
   | 'capacityCommitmentStatsPerEpoch__activeUnitCount'
-  | 'capacityCommitmentStatsPerEpoch__blockNumberEnd'
-  | 'capacityCommitmentStatsPerEpoch__blockNumberStart'
   | 'capacityCommitmentStatsPerEpoch__computeUnitsWithMinRequiredProofsSubmittedCounter'
   | 'capacityCommitmentStatsPerEpoch__currentCCNextCCFailedEpoch'
   | 'capacityCommitmentStatsPerEpoch__epoch'
@@ -3022,6 +3175,7 @@ export type SubmittedProof_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
@@ -3035,6 +3189,7 @@ export type SubmittedProof_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'
@@ -3073,6 +3228,8 @@ export type Subscription = {
   deals: Array<Deal>;
   effector?: Maybe<Effector>;
   effectors: Array<Effector>;
+  epochStatistic?: Maybe<EpochStatistic>;
+  epochStatistics: Array<EpochStatistic>;
   graphNetwork?: Maybe<GraphNetwork>;
   graphNetworks: Array<GraphNetwork>;
   offer?: Maybe<Offer>;
@@ -3290,6 +3447,24 @@ export type SubscriptionEffectorsArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Effector_Filter>;
+};
+
+
+export type SubscriptionEpochStatisticArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionEpochStatisticsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<EpochStatistic_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<EpochStatistic_Filter>;
 };
 
 

--- a/ts-client/src/dealCliClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealCliClient/indexerClient/generated.types.ts
@@ -1757,6 +1757,11 @@ export type EpochStatistic_OrderBy =
   | 'startBlock'
   | 'startTimestamp';
 
+/**
+ * In the scheme below used behaviour where deleted entity marked as deleted=True instead of actual deletion (in contrast as in contract).
+ * Thus, please refer to the field when querying the data.
+ *
+ */
 export type GraphNetwork = {
   __typename?: 'GraphNetwork';
   capacityCommitmentsTotal: Scalars['BigInt']['output'];

--- a/ts-client/src/dealCliClient/indexerClient/queries/offers-query.generated.ts
+++ b/ts-client/src/dealCliClient/indexerClient/queries/offers-query.generated.ts
@@ -57,9 +57,9 @@ export const OfferDetailFragmentDoc = gql`
     approved
     name
   }
-  peers {
+  peers(where: {deleted: false}) {
     id
-    computeUnits {
+    computeUnits(where: {deleted: false}) {
       ...ComputeUnitBasic
     }
   }

--- a/ts-client/src/dealCliClient/indexerClient/queries/offers-query.graphql
+++ b/ts-client/src/dealCliClient/indexerClient/queries/offers-query.graphql
@@ -1,3 +1,6 @@
+# Exclude deleted CUs.
+# Exclude deleted Peers.
+
 query OfferQuery(
   $id: ID!
 ) {
@@ -28,9 +31,9 @@ fragment OfferDetail on Offer {
       approved
       name
     }
-    peers {
+    peers(where: {deleted: false}) {
         id
-        computeUnits {
+        computeUnits(where: {deleted: false}) {
             ...ComputeUnitBasic
         }
     }

--- a/ts-client/src/dealCliClient/serializers/schemes.ts
+++ b/ts-client/src/dealCliClient/serializers/schemes.ts
@@ -1,22 +1,28 @@
 import type { OfferDetail, Peer } from "../types/schemes.js";
-import type {
-  OfferDetailFragment
-} from "../indexerClient/queries/offers-query.generated.js";
-import { type SerializationSettings, tokenValueToRounded } from "../../utils/serializers.js";
+import type { OfferDetailFragment } from "../indexerClient/queries/offers-query.generated.js";
+import {
+  type SerializationSettings,
+  tokenValueToRounded,
+} from "../../utils/serializers.js";
 import { serializeEffectors } from "../../utils/indexerClient/serializers.js";
 
-export function serializeOfferDetail(offer: OfferDetailFragment, serializationSettings: SerializationSettings): OfferDetail {
-  const serializedPeers: Array<Peer> = offer.peers?.map((peer) => {
-    return {
-      id: peer.id,
-      computeUnits: peer.computeUnits?.map(
-        (computeUnit) => {return {
-          id: computeUnit.id,
-          workerId: computeUnit.workerId ?? undefined,
-        }}
-      ) ?? []
-    }
-  }) ?? []
+export function serializeOfferDetail(
+  offer: OfferDetailFragment,
+  serializationSettings: SerializationSettings,
+): OfferDetail {
+  const serializedPeers: Array<Peer> =
+    offer.peers?.map((peer) => {
+      return {
+        id: peer.id,
+        computeUnits:
+          peer.computeUnits?.map((computeUnit) => {
+            return {
+              id: computeUnit.id,
+              workerId: computeUnit.workerId ?? undefined,
+            };
+          }) ?? [],
+      };
+    }) ?? [];
   return {
     id: offer.id,
     createdAt: Number(offer.createdAt),

--- a/ts-client/src/dealCliClient/types/schemes.ts
+++ b/ts-client/src/dealCliClient/types/schemes.ts
@@ -19,12 +19,10 @@ export type Peer = {
   computeUnits: Array<ComputeUnit>;
 };
 
-
 export type Effector = {
   cid: string;
   description: string;
 };
-
 
 export interface OfferDetail {
   id: string;

--- a/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
@@ -633,6 +633,7 @@ export type CapacityCommitment_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'
@@ -955,6 +956,7 @@ export type ComputeUnit_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'
@@ -1240,6 +1242,7 @@ export type DealToJoinedOfferPeer_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals';
 
@@ -1341,6 +1344,7 @@ export type DealToPeer_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals';
 
@@ -2258,6 +2262,7 @@ export type Peer = {
   currentCCEndEpoch?: Maybe<Scalars['BigInt']['output']>;
   currentCCNextCCFailedEpoch?: Maybe<Scalars['BigInt']['output']>;
   currentCapacityCommitment?: Maybe<CapacityCommitment>;
+  deleted: Scalars['Boolean']['output'];
   /** ref to peerId in contract. */
   id: Scalars['ID']['output'];
   isAnyJoinedDeals: Scalars['Boolean']['output'];
@@ -2360,6 +2365,10 @@ export type Peer_Filter = {
   currentCapacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   currentCapacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
   currentCapacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  deleted_not?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -2448,6 +2457,7 @@ export type Peer_OrderBy =
   | 'currentCapacityCommitment__submittedProofsCount'
   | 'currentCapacityCommitment__totalCollateral'
   | 'currentCapacityCommitment__totalFailCount'
+  | 'deleted'
   | 'id'
   | 'isAnyJoinedDeals'
   | 'joinedDeals'
@@ -3179,6 +3189,7 @@ export type SubmittedProof_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'

--- a/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/generated.types.ts
@@ -383,6 +383,7 @@ export type CapacityCommitmentToComputeUnit_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
@@ -657,6 +658,7 @@ export type ComputeUnit = {
   __typename?: 'ComputeUnit';
   createdAt: Scalars['BigInt']['output'];
   deal?: Maybe<Deal>;
+  deleted: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   peer: Peer;
   /** In order to simplify relation for query. */
@@ -796,6 +798,7 @@ export type ComputeUnitPerEpochStat_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
@@ -841,6 +844,10 @@ export type ComputeUnit_Filter = {
   deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   deal_starts_with?: InputMaybe<Scalars['String']['input']>;
   deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  deleted_not?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -940,6 +947,7 @@ export type ComputeUnit_OrderBy =
   | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
+  | 'deleted'
   | 'id'
   | 'peer'
   | 'peer__computeUnitsInDeal'
@@ -1680,7 +1688,7 @@ export type Effector_OrderBy =
   | 'id'
   | 'offers';
 
-/** This model is designed to store epoch related information. Note, that in other models it is more efficient to use epoch as bigint rather than with relation to that model (with relation you could complicate your queries and need to store additional epoch field). */
+/** This model is designed to store epoch related information. Note, that in other models it is more efficient to store epoch as bigint rather than relation to that model (with relation you could complicate your queries by epoch, or you will need to store additional epoch field anyway). */
 export type EpochStatistic = {
   __typename?: 'EpochStatistic';
   endBlock: Scalars['BigInt']['output'];
@@ -1764,7 +1772,7 @@ export type GraphNetwork = {
   proofsTotal: Scalars['BigInt']['output'];
   /** Providers that register themselves in the network with setInfo() method. */
   providersRegisteredTotal: Scalars['BigInt']['output'];
-  /** @deprecated TODO: deprecate. */
+  /** @deprecated TODO: deprecate because it is not used. changed to providersRegisteredTotal used. */
   providersTotal: Scalars['BigInt']['output'];
   tokensTotal: Scalars['BigInt']['output'];
 };
@@ -1969,6 +1977,7 @@ export type GraphNetwork_OrderBy =
 
 export type Offer = {
   __typename?: 'Offer';
+  /** It depends on if CU in deal or not. */
   computeUnitsAvailable?: Maybe<Scalars['Int']['output']>;
   computeUnitsTotal?: Maybe<Scalars['Int']['output']>;
   createdAt: Scalars['BigInt']['output'];
@@ -2462,6 +2471,7 @@ export type Peer_OrderBy =
 export type Provider = {
   __typename?: 'Provider';
   approved: Scalars['Boolean']['output'];
+  /** It depends on if CU in deal or not. */
   computeUnitsAvailable: Scalars['Int']['output'];
   computeUnitsTotal: Scalars['Int']['output'];
   createdAt: Scalars['BigInt']['output'];
@@ -3155,6 +3165,7 @@ export type SubmittedProof_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/capacity-commitments-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/capacity-commitments-query.generated.ts
@@ -119,7 +119,7 @@ export const CapacityCommitmentQueryDocument = gql`
   capacityCommitment(id: $id) {
     ...CapacityCommitmentBasic
     delegator
-    computeUnits {
+    computeUnits(where: {computeUnit_: {deleted: false}}) {
       computeUnit {
         id
         deal {

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/capacity-commitments-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/capacity-commitments-query.graphql
@@ -1,3 +1,5 @@
+# Exclude deleted CUs.
+
 query CapacityCommitmentsQuery(
   $filters: CapacityCommitment_filter
   $offset: Int
@@ -23,7 +25,8 @@ query CapacityCommitmentQuery($id: ID!) {
   capacityCommitment(id: $id) {
     ...CapacityCommitmentBasic
     delegator
-    computeUnits {
+    # Exclude deleted CUs.
+    computeUnits(where: {computeUnit_: {deleted: false}}) {
       computeUnit {
         id
         deal {

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.generated.ts
@@ -75,7 +75,7 @@ export const BasicDealFragmentDoc = gql`
       ...EffectorBasic
     }
   }
-  addedComputeUnits {
+  addedComputeUnits(where: {deleted: false}) {
     ...ComputeUnitBasic
   }
   providersAccessType
@@ -128,7 +128,7 @@ export const DealsByPeerQueryDocument = gql`
     ) {
       deal {
         id
-        addedComputeUnits(where: {peer_: {id: $peerId}}) {
+        addedComputeUnits(where: {peer_: {id: $peerId}, deleted: false}) {
           id
           workerId
         }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/deals-query.graphql
@@ -1,3 +1,5 @@
+# Exclude deleted CUs.
+
 query DealsQuery(
   $filters: Deal_filter,
   $offset: Int,
@@ -48,7 +50,10 @@ fragment BasicDeal on Deal {
         ...EffectorBasic
       }
     }
-    addedComputeUnits {
+    addedComputeUnits(
+      # Exclude deleted CUs.
+      where: {deleted: false}
+    ) {
         ...ComputeUnitBasic
     }
     providersAccessType
@@ -93,7 +98,11 @@ query DealsByPeerQuery(
       deal {
         id
         addedComputeUnits(
-          where: {peer_: {id: $peerId}}
+          where: {
+            peer_: {id: $peerId}
+            # Exclude deleted CUs.
+            deleted: false
+          }
         ) {
           id
           workerId

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.generated.ts
@@ -81,7 +81,7 @@ export const BasicOfferFragmentDoc = gql`
     approved
     name
   }
-  peers {
+  peers(where: {deleted: false}) {
     id
   }
 }
@@ -130,7 +130,7 @@ export const OfferQueryDocument = gql`
   offer(id: $id) {
     ...BasicOffer
     updatedAt
-    peers {
+    peers(where: {deleted: false}) {
       ...BasicPeer
     }
   }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.generated.ts
@@ -104,7 +104,7 @@ export const BasicPeerFragmentDoc = gql`
   provider {
     id
   }
-  computeUnits {
+  computeUnits(where: {deleted: false}) {
     ...ComputeUnitBasic
   }
 }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.graphql
@@ -1,4 +1,5 @@
 # Exclude deleted CUs.
+# Exclude deleted Peers.
 
 query OffersQuery(
   $filters: Offer_filter,
@@ -27,7 +28,8 @@ query OfferQuery(
   offer(id: $id) {
     ...BasicOffer
     updatedAt
-    peers {
+    # Exclude deleted Peers.
+    peers(where: {deleted: false}) {
         ...BasicPeer
     }
   }
@@ -54,7 +56,7 @@ fragment BasicOffer on Offer {
       approved
       name
     }
-    peers {
+    peers(where: {deleted: false}) {
       id
     }
 }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/offers-query.graphql
@@ -1,3 +1,5 @@
+# Exclude deleted CUs.
+
 query OffersQuery(
   $filters: Offer_filter,
   $offset: Int,
@@ -65,7 +67,10 @@ fragment BasicPeer on Peer {
     provider {
         id
     }
-    computeUnits {
+    computeUnits(
+      # Exclude deleted CUs.
+      where: {deleted: false}
+    ) {
         ...ComputeUnitBasic
     }
 }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.generated.ts
@@ -88,7 +88,7 @@ export const ComputeUnitQueryDocument = gql`
 export const ComputeUnitsQueryDocument = gql`
     query ComputeUnitsQuery($filters: ComputeUnit_filter, $offset: Int, $limit: Int, $orderBy: ComputeUnit_orderBy, $orderType: OrderDirection) {
   computeUnits(
-    where: $filters
+    where: {and: [$filters, {deleted: false}]}
     first: $limit
     skip: $offset
     orderBy: $orderBy

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/peers-query.graphql
@@ -1,3 +1,5 @@
+# Exclude deleted CUs.
+
 query PeerQuery(
   $id: ID!
 ) {
@@ -59,7 +61,12 @@ query ComputeUnitsQuery(
   $orderType: OrderDirection,
 ) {
   computeUnits(
-    where: $filters
+    where: {
+      and: [
+        $filters,
+        # Exclude deleted CUs.
+        {deleted: false}
+      ]}
     first: $limit
     skip: $offset
     orderBy: $orderBy

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.generated.ts
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.generated.ts
@@ -68,7 +68,7 @@ export const ProvidersBasicOfferFragmentDoc = gql`
   provider {
     id
   }
-  peers {
+  peers(where: {deleted: false}) {
     id
   }
 }

--- a/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.graphql
+++ b/ts-client/src/dealExplorerClient/indexerClient/queries/providers-query.graphql
@@ -1,3 +1,5 @@
+# Exclude deleted Peers.
+
 query ProvidersQuery(
   $filters: Provider_filter,
   $offset: Int,
@@ -66,7 +68,7 @@ fragment ProvidersBasicOffer on Offer {
     provider {
       id
     }
-    peers {
+    peers(where: {deleted: false}) {
       id
     }
 }

--- a/ts-client/src/dealExplorerClient/serializers/filters.ts
+++ b/ts-client/src/dealExplorerClient/serializers/filters.ts
@@ -15,9 +15,7 @@ import type {
   Provider_Filter,
 } from "../indexerClient/generated.types.js";
 import { valueToTokenValue } from "../../utils/serializers.js";
-import {
-  serializePercentageToContractRate
-} from "../../utils/indexerClient/serializers.js";
+import { serializePercentageToContractRate } from "../../utils/indexerClient/serializers.js";
 
 export class FiltersError extends Error {}
 export class ValidTogetherFiltersError extends FiltersError {}
@@ -233,12 +231,18 @@ export function serializeCapacityCommitmentsFiltersToIndexer(
   }
   if (v.rewardDelegatorRateFrom) {
     convertedFilters.and?.push({
-      rewardDelegatorRate_gte: serializePercentageToContractRate(v.rewardDelegatorRateFrom, precision),
+      rewardDelegatorRate_gte: serializePercentageToContractRate(
+        v.rewardDelegatorRateFrom,
+        precision,
+      ),
     });
   }
   if (v.rewardDelegatorRateTo) {
     convertedFilters.and?.push({
-      rewardDelegatorRate_lte: serializePercentageToContractRate(v.rewardDelegatorRateTo, precision),
+      rewardDelegatorRate_lte: serializePercentageToContractRate(
+        v.rewardDelegatorRateTo,
+        precision,
+      ),
     });
   }
   // TODO: deprecate onlyActive.

--- a/ts-client/src/dealExplorerClient/serializers/logics.ts
+++ b/ts-client/src/dealExplorerClient/serializers/logics.ts
@@ -5,7 +5,7 @@ import type { ComputeUnitWithCcDataBasicFragment } from "../indexerClient/querie
 import type { ComputeUnitStatus } from "../types/schemes.js";
 import {
   type SerializationSettings,
-  tokenValueToRounded
+  tokenValueToRounded,
 } from "../../utils/serializers.js";
 import { FLTToken } from "../constants.js";
 
@@ -49,22 +49,21 @@ export function serializeRewards(
   delegatorRate: number,
   precision: number,
   serializationSettings: SerializationSettings,
-): {provider: string, delegator: string} {
+): { provider: string; delegator: string } {
   const delegatorRateBigInt = BigInt(delegatorRate);
   const precisionBigInt = BigInt(precision);
-  const delegatorReward = (value * delegatorRateBigInt) / precisionBigInt
-  const providerReward = value - delegatorReward
+  const delegatorReward = (value * delegatorRateBigInt) / precisionBigInt;
+  const providerReward = value - delegatorReward;
   return {
-    provider:
-      tokenValueToRounded(
-        providerReward,
-        Number(FLTToken.decimals),
-        serializationSettings.nativeTokenValueAdditionalFormatter,
-        ),
+    provider: tokenValueToRounded(
+      providerReward,
+      Number(FLTToken.decimals),
+      serializationSettings.nativeTokenValueAdditionalFormatter,
+    ),
     delegator: tokenValueToRounded(
       delegatorReward,
       Number(FLTToken.decimals),
       serializationSettings.nativeTokenValueAdditionalFormatter,
-      ),
-  }
+    ),
+  };
 }

--- a/ts-client/src/dealExplorerClient/serializers/orderby.ts
+++ b/ts-client/src/dealExplorerClient/serializers/orderby.ts
@@ -9,7 +9,7 @@ import type {
   CapacityCommitment_OrderBy,
   Deal_OrderBy,
   Offer_OrderBy,
-  SubmittedProof_OrderBy
+  SubmittedProof_OrderBy,
 } from "../indexerClient/generated.types.js";
 
 export function serializeOfferShortOrderByToIndexer(

--- a/ts-client/src/dealExplorerClient/serializers/schemes.ts
+++ b/ts-client/src/dealExplorerClient/serializers/schemes.ts
@@ -11,7 +11,7 @@ import type {
   OfferShort,
   Peer,
   ProviderBase,
-  ProviderShort
+  ProviderShort,
 } from "../types/schemes.js";
 import type {
   BasicOfferFragment,
@@ -22,30 +22,29 @@ import {
   serializeProviderName,
   serializeRewards,
 } from "./logics.js";
-import {
-  calculateTimestamp,
-} from "../utils.js";
+import { calculateTimestamp } from "../utils.js";
 import type {
   BasicDealFragment,
   ComputeUnitBasicFragment,
 } from "../indexerClient/queries/deals-query.generated.js";
 import type { CapacityCommitmentBasicFragment } from "../indexerClient/queries/capacity-commitments-query.generated.js";
 import { FLTToken } from "../constants.js";
-import type {
-  ComputeUnitWithCcDataBasicFragment
-} from "../indexerClient/queries/peers-query.generated.js";
+import type { ComputeUnitWithCcDataBasicFragment } from "../indexerClient/queries/peers-query.generated.js";
 import {
   type SerializationSettings,
-  tokenValueToRounded
+  tokenValueToRounded,
 } from "../../utils/serializers.js";
 import {
   serializeEffectors,
-  serializeContractRateToPercentage
+  serializeContractRateToPercentage,
 } from "../../utils/indexerClient/serializers.js";
 
-const BIG_INT_ZERO = BigInt(0)
+const BIG_INT_ZERO = BigInt(0);
 
-export function serializeOfferShort(offer: BasicOfferFragment, serializationSettings: SerializationSettings,): OfferShort {
+export function serializeOfferShort(
+  offer: BasicOfferFragment,
+  serializationSettings: SerializationSettings,
+): OfferShort {
   return {
     id: offer.id,
     createdAt: Number(offer.createdAt),
@@ -89,7 +88,9 @@ export function serializeProviderShort(
   const composedOffers = [];
   if (provider.offers) {
     for (const offer of provider.offers) {
-      composedOffers.push(serializeOfferShort(offer as BasicOfferFragment, serializationSettings));
+      composedOffers.push(
+        serializeOfferShort(offer as BasicOfferFragment, serializationSettings),
+      );
     }
   }
   return {
@@ -112,14 +113,11 @@ export function serializeComputeUnits(
 }
 
 export function serializeComputeUnitsWithStatus(
-  computeUnitsWithCcDataBasicFragment: Array<ComputeUnitWithCcDataBasicFragment>
+  computeUnitsWithCcDataBasicFragment: Array<ComputeUnitWithCcDataBasicFragment>,
 ): Array<ComputeUnitsWithCCStatus> {
   let res: Array<ComputeUnitsWithCCStatus> = [];
   for (const computeUnit of computeUnitsWithCcDataBasicFragment) {
-    const { status } =
-      serializeCUStatus(
-        computeUnit,
-      );
+    const { status } = serializeCUStatus(computeUnit);
 
     res.push({
       id: computeUnit.id,
@@ -128,7 +126,7 @@ export function serializeComputeUnitsWithStatus(
       successProofs: computeUnit.submittedProofsCount,
     });
   }
-  return res
+  return res;
 }
 
 export function serializePeers(peers: Array<BasicPeerFragment>): Array<Peer> {
@@ -251,21 +249,26 @@ export function serializeCapacityCommitmentDetail(
   precision: number,
 ): CapacityCommitmentDetail {
   const _totalRewards = totalRewards ? BigInt(totalRewards) : BIG_INT_ZERO;
-  const _unlockedRewards = unlockedRewards ? BigInt(unlockedRewards) : BIG_INT_ZERO;
+  const _unlockedRewards = unlockedRewards
+    ? BigInt(unlockedRewards)
+    : BIG_INT_ZERO;
   // First of all convert to [0, 1] with accordance of precision and than to [0, 100] to % format.
-  const rewardDelegatorRatePercentage = serializeContractRateToPercentage(rewardDelegatorRate, precision);
+  const rewardDelegatorRatePercentage = serializeContractRateToPercentage(
+    rewardDelegatorRate,
+    precision,
+  );
   const unclockedRewardsSerialized = serializeRewards(
     _unlockedRewards,
     rewardDelegatorRate,
     precision,
     serializationSettings,
-  )
+  );
   const notWithdrawnRewardsSerialized = serializeRewards(
     _totalRewards,
     rewardDelegatorRate,
     precision,
     serializationSettings,
-  )
+  );
   return {
     ...serializeCapacityCommitmentShort(
       capacityCommitmentFromIndexer,

--- a/ts-client/src/dealMatcherClient/dealMatcherClient.ts
+++ b/ts-client/src/dealMatcherClient/dealMatcherClient.ts
@@ -92,6 +92,7 @@ export class DealMatcherClient {
       peersFilters: {
         and: [
           {
+            deleted: false,
             computeUnits_: { deal: null, deleted: false },
             // Check for CC Active status below and depends on provider whitlist filter.
           },
@@ -139,6 +140,7 @@ export class DealMatcherClient {
       // No whitelist, thus, check for active cc status is required.
       // For Peers.
       indexerGetOffersParams.filters!["peers_"] = {
+        deleted: false,
         // Do not fetch peers with no any of compute units in "active" status at all.
         // Check if CU status is Active - if it has current capacity commitment and
         //  cc.info.startEpoch <= currentEpoch_.

--- a/ts-client/src/dealMatcherClient/dealMatcherClient.ts
+++ b/ts-client/src/dealMatcherClient/dealMatcherClient.ts
@@ -1,12 +1,10 @@
 import { IndexerClient } from "./indexerClient/indexerClient.js";
 import type { ContractsENV } from "../client/config.js";
 import type { OffersQueryQueryVariables } from "./indexerClient/queries/offers-query.generated.js";
-import {
-  serializeDealProviderAccessLists
-} from "../utils/indexerClient/serializers.js";
+import { serializeDealProviderAccessLists } from "../utils/indexerClient/serializers.js";
 import { getLogger } from "../utils/logger.js";
 
-const logger = getLogger("deal-ts-clients:dealMatcherClient")
+const logger = getLogger("deal-ts-clients:dealMatcherClient");
 
 // Structure match matchDeal() arguments.
 // Currently: bytes32[] calldata offers, bytes32[][] calldata computeUnits.

--- a/ts-client/src/dealMatcherClient/dealMatcherClient.ts
+++ b/ts-client/src/dealMatcherClient/dealMatcherClient.ts
@@ -92,7 +92,7 @@ export class DealMatcherClient {
       peersFilters: {
         and: [
           {
-            computeUnits_: { deal: null },
+            computeUnits_: { deal: null, deleted: false },
             // Check for CC Active status below and depends on provider whitlist filter.
           },
           {
@@ -110,7 +110,7 @@ export class DealMatcherClient {
           },
         ],
       },
-      computeUnitsFilters: { deal: null },
+      computeUnitsFilters: { deal: null, deleted: false },
       peersLimit: peersPerPageLimit,
       // We do not need more than 1 CU per peer. Apply restriction to already fetched and filtered data.
       computeUnitsLimit: 1,

--- a/ts-client/src/dealMatcherClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealMatcherClient/indexerClient/generated.types.ts
@@ -633,6 +633,7 @@ export type CapacityCommitment_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'
@@ -955,6 +956,7 @@ export type ComputeUnit_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'
@@ -1240,6 +1242,7 @@ export type DealToJoinedOfferPeer_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals';
 
@@ -1341,6 +1344,7 @@ export type DealToPeer_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals';
 
@@ -2258,6 +2262,7 @@ export type Peer = {
   currentCCEndEpoch?: Maybe<Scalars['BigInt']['output']>;
   currentCCNextCCFailedEpoch?: Maybe<Scalars['BigInt']['output']>;
   currentCapacityCommitment?: Maybe<CapacityCommitment>;
+  deleted: Scalars['Boolean']['output'];
   /** ref to peerId in contract. */
   id: Scalars['ID']['output'];
   isAnyJoinedDeals: Scalars['Boolean']['output'];
@@ -2360,6 +2365,10 @@ export type Peer_Filter = {
   currentCapacityCommitment_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   currentCapacityCommitment_starts_with?: InputMaybe<Scalars['String']['input']>;
   currentCapacityCommitment_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  deleted_not?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -2448,6 +2457,7 @@ export type Peer_OrderBy =
   | 'currentCapacityCommitment__submittedProofsCount'
   | 'currentCapacityCommitment__totalCollateral'
   | 'currentCapacityCommitment__totalFailCount'
+  | 'deleted'
   | 'id'
   | 'isAnyJoinedDeals'
   | 'joinedDeals'
@@ -3179,6 +3189,7 @@ export type SubmittedProof_OrderBy =
   | 'peer__currentCCCollateralDepositedAt'
   | 'peer__currentCCEndEpoch'
   | 'peer__currentCCNextCCFailedEpoch'
+  | 'peer__deleted'
   | 'peer__id'
   | 'peer__isAnyJoinedDeals'
   | 'provider'

--- a/ts-client/src/dealMatcherClient/indexerClient/generated.types.ts
+++ b/ts-client/src/dealMatcherClient/indexerClient/generated.types.ts
@@ -55,6 +55,7 @@ export type CapacityCommitment = {
   nextCCFailedEpoch: Scalars['BigInt']['output'];
   peer: Peer;
   provider: Provider;
+  /** This field represents Ratio [0, 1] only when it is divided by PRECISION constant of Core contract. */
   rewardDelegatorRate: Scalars['Int']['output'];
   rewardWithdrawn: Scalars['BigInt']['output'];
   snapshotEpoch: Scalars['BigInt']['output'];
@@ -98,13 +99,13 @@ export type CapacityCommitmentSubmittedProofsArgs = {
 export type CapacityCommitmentStatsPerEpoch = {
   __typename?: 'CapacityCommitmentStatsPerEpoch';
   activeUnitCount: Scalars['Int']['output'];
-  blockNumberEnd: Scalars['BigInt']['output'];
-  blockNumberStart: Scalars['BigInt']['output'];
   capacityCommitment: CapacityCommitment;
   /** Should be update after ComputeUnitPerEpochStat.submittedProofsCount reached min proofs border. */
   computeUnitsWithMinRequiredProofsSubmittedCounter: Scalars['Int']['output'];
   currentCCNextCCFailedEpoch: Scalars['BigInt']['output'];
+  /** Additional field to support ordering by epoch. */
   epoch: Scalars['BigInt']['output'];
+  epochStatistic: EpochStatistic;
   exitedUnitCount: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   nextAdditionalActiveUnitCount: Scalars['Int']['output'];
@@ -135,22 +136,6 @@ export type CapacityCommitmentStatsPerEpoch_Filter = {
   activeUnitCount_not?: InputMaybe<Scalars['Int']['input']>;
   activeUnitCount_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   and?: InputMaybe<Array<InputMaybe<CapacityCommitmentStatsPerEpoch_Filter>>>;
-  blockNumberEnd?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  blockNumberEnd_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_not?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberEnd_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  blockNumberStart?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  blockNumberStart_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_not?: InputMaybe<Scalars['BigInt']['input']>;
-  blockNumberStart_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   capacityCommitment?: InputMaybe<Scalars['String']['input']>;
   capacityCommitment_?: InputMaybe<CapacityCommitment_Filter>;
   capacityCommitment_contains?: InputMaybe<Scalars['String']['input']>;
@@ -189,6 +174,27 @@ export type CapacityCommitmentStatsPerEpoch_Filter = {
   currentCCNextCCFailedEpoch_not?: InputMaybe<Scalars['BigInt']['input']>;
   currentCCNextCCFailedEpoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   epoch?: InputMaybe<Scalars['BigInt']['input']>;
+  epochStatistic?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_?: InputMaybe<EpochStatistic_Filter>;
+  epochStatistic_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_lt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_lte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   epoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
   epoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
   epoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
@@ -242,8 +248,6 @@ export type CapacityCommitmentStatsPerEpoch_Filter = {
 
 export type CapacityCommitmentStatsPerEpoch_OrderBy =
   | 'activeUnitCount'
-  | 'blockNumberEnd'
-  | 'blockNumberStart'
   | 'capacityCommitment'
   | 'capacityCommitment__activeUnitCount'
   | 'capacityCommitment__collateralPerUnit'
@@ -269,6 +273,12 @@ export type CapacityCommitmentStatsPerEpoch_OrderBy =
   | 'computeUnitsWithMinRequiredProofsSubmittedCounter'
   | 'currentCCNextCCFailedEpoch'
   | 'epoch'
+  | 'epochStatistic'
+  | 'epochStatistic__endBlock'
+  | 'epochStatistic__endTimestamp'
+  | 'epochStatistic__id'
+  | 'epochStatistic__startBlock'
+  | 'epochStatistic__startTimestamp'
   | 'exitedUnitCount'
   | 'id'
   | 'nextAdditionalActiveUnitCount'
@@ -373,6 +383,7 @@ export type CapacityCommitmentToComputeUnit_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
@@ -647,6 +658,7 @@ export type ComputeUnit = {
   __typename?: 'ComputeUnit';
   createdAt: Scalars['BigInt']['output'];
   deal?: Maybe<Deal>;
+  deleted: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   peer: Peer;
   /** In order to simplify relation for query. */
@@ -670,7 +682,7 @@ export type ComputeUnitPerEpochStat = {
   __typename?: 'ComputeUnitPerEpochStat';
   capacityCommitment?: Maybe<CapacityCommitment>;
   computeUnit: ComputeUnit;
-  epoch: Scalars['BigInt']['output'];
+  epochStatistic: EpochStatistic;
   id: Scalars['ID']['output'];
   submittedProofsCount: Scalars['Int']['output'];
 };
@@ -721,14 +733,27 @@ export type ComputeUnitPerEpochStat_Filter = {
   computeUnit_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   computeUnit_starts_with?: InputMaybe<Scalars['String']['input']>;
   computeUnit_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  epoch?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_gt?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_gte?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
-  epoch_lt?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_lte?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_not?: InputMaybe<Scalars['BigInt']['input']>;
-  epoch_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  epochStatistic?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_?: InputMaybe<EpochStatistic_Filter>;
+  epochStatistic_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_gte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_lt?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_lte?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  epochStatistic_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with?: InputMaybe<Scalars['String']['input']>;
+  epochStatistic_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -773,10 +798,16 @@ export type ComputeUnitPerEpochStat_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
-  | 'epoch'
+  | 'epochStatistic'
+  | 'epochStatistic__endBlock'
+  | 'epochStatistic__endTimestamp'
+  | 'epochStatistic__id'
+  | 'epochStatistic__startBlock'
+  | 'epochStatistic__startTimestamp'
   | 'id'
   | 'submittedProofsCount';
 
@@ -813,6 +844,10 @@ export type ComputeUnit_Filter = {
   deal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
   deal_starts_with?: InputMaybe<Scalars['String']['input']>;
   deal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  deleted?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  deleted_not?: InputMaybe<Scalars['Boolean']['input']>;
+  deleted_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
   id?: InputMaybe<Scalars['ID']['input']>;
   id_gt?: InputMaybe<Scalars['ID']['input']>;
   id_gte?: InputMaybe<Scalars['ID']['input']>;
@@ -912,6 +947,7 @@ export type ComputeUnit_OrderBy =
   | 'deal__registeredWorkersCurrentCount'
   | 'deal__targetWorkers'
   | 'deal__withdrawalSum'
+  | 'deleted'
   | 'id'
   | 'peer'
   | 'peer__computeUnitsInDeal'
@@ -1652,6 +1688,71 @@ export type Effector_OrderBy =
   | 'id'
   | 'offers';
 
+/** This model is designed to store epoch related information. Note, that in other models it is more efficient to store epoch as bigint rather than relation to that model (with relation you could complicate your queries by epoch, or you will need to store additional epoch field anyway). */
+export type EpochStatistic = {
+  __typename?: 'EpochStatistic';
+  endBlock: Scalars['BigInt']['output'];
+  endTimestamp: Scalars['BigInt']['output'];
+  /** Epoch number. Note, that for current epoch right boarder is approximate. */
+  id: Scalars['ID']['output'];
+  startBlock: Scalars['BigInt']['output'];
+  startTimestamp: Scalars['BigInt']['output'];
+};
+
+export type EpochStatistic_Filter = {
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<EpochStatistic_Filter>>>;
+  endBlock?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endBlock_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_not?: InputMaybe<Scalars['BigInt']['input']>;
+  endBlock_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endTimestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  endTimestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  endTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  or?: InputMaybe<Array<InputMaybe<EpochStatistic_Filter>>>;
+  startBlock?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startBlock_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_not?: InputMaybe<Scalars['BigInt']['input']>;
+  startBlock_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startTimestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  startTimestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  startTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+};
+
+export type EpochStatistic_OrderBy =
+  | 'endBlock'
+  | 'endTimestamp'
+  | 'id'
+  | 'startBlock'
+  | 'startTimestamp';
+
 export type GraphNetwork = {
   __typename?: 'GraphNetwork';
   capacityCommitmentsTotal: Scalars['BigInt']['output'];
@@ -1659,6 +1760,7 @@ export type GraphNetwork = {
   capacityMaxFailedRatio?: Maybe<Scalars['Int']['output']>;
   coreContractAddress?: Maybe<Scalars['String']['output']>;
   coreEpochDuration?: Maybe<Scalars['Int']['output']>;
+  corePrecision?: Maybe<Scalars['Int']['output']>;
   dealsTotal: Scalars['BigInt']['output'];
   effectorsTotal: Scalars['BigInt']['output'];
   /** ID is set to 1 */
@@ -1668,6 +1770,9 @@ export type GraphNetwork = {
   minRequiredProofsPerEpoch?: Maybe<Scalars['Int']['output']>;
   offersTotal: Scalars['BigInt']['output'];
   proofsTotal: Scalars['BigInt']['output'];
+  /** Providers that register themselves in the network with setInfo() method. */
+  providersRegisteredTotal: Scalars['BigInt']['output'];
+  /** @deprecated TODO: deprecate because it is not used. changed to providersRegisteredTotal used. */
   providersTotal: Scalars['BigInt']['output'];
   tokensTotal: Scalars['BigInt']['output'];
 };
@@ -1740,6 +1845,14 @@ export type GraphNetwork_Filter = {
   coreEpochDuration_lte?: InputMaybe<Scalars['Int']['input']>;
   coreEpochDuration_not?: InputMaybe<Scalars['Int']['input']>;
   coreEpochDuration_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  corePrecision?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_gt?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_gte?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  corePrecision_lt?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_lte?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_not?: InputMaybe<Scalars['Int']['input']>;
+  corePrecision_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   dealsTotal?: InputMaybe<Scalars['BigInt']['input']>;
   dealsTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
   dealsTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -1817,6 +1930,14 @@ export type GraphNetwork_Filter = {
   proofsTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
   proofsTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
   proofsTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersRegisteredTotal?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  providersRegisteredTotal_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_not?: InputMaybe<Scalars['BigInt']['input']>;
+  providersRegisteredTotal_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   providersTotal?: InputMaybe<Scalars['BigInt']['input']>;
   providersTotal_gt?: InputMaybe<Scalars['BigInt']['input']>;
   providersTotal_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -1841,6 +1962,7 @@ export type GraphNetwork_OrderBy =
   | 'capacityMaxFailedRatio'
   | 'coreContractAddress'
   | 'coreEpochDuration'
+  | 'corePrecision'
   | 'dealsTotal'
   | 'effectorsTotal'
   | 'id'
@@ -1849,11 +1971,13 @@ export type GraphNetwork_OrderBy =
   | 'minRequiredProofsPerEpoch'
   | 'offersTotal'
   | 'proofsTotal'
+  | 'providersRegisteredTotal'
   | 'providersTotal'
   | 'tokensTotal';
 
 export type Offer = {
   __typename?: 'Offer';
+  /** It depends on if CU in deal or not. */
   computeUnitsAvailable?: Maybe<Scalars['Int']['output']>;
   computeUnitsTotal?: Maybe<Scalars['Int']['output']>;
   createdAt: Scalars['BigInt']['output'];
@@ -2347,6 +2471,7 @@ export type Peer_OrderBy =
 export type Provider = {
   __typename?: 'Provider';
   approved: Scalars['Boolean']['output'];
+  /** It depends on if CU in deal or not. */
   computeUnitsAvailable: Scalars['Int']['output'];
   computeUnitsTotal: Scalars['Int']['output'];
   createdAt: Scalars['BigInt']['output'];
@@ -2354,7 +2479,7 @@ export type Provider = {
   name: Scalars['String']['output'];
   offers?: Maybe<Array<Offer>>;
   peerCount: Scalars['Int']['output'];
-  /** Is provider registered in the network (if false - possible just mentioned). */
+  /** Is provider registered in the network (if false possibly it is only mentioned or global-whitelisted). */
   registered: Scalars['Boolean']['output'];
 };
 
@@ -2480,6 +2605,8 @@ export type Query = {
   deals: Array<Deal>;
   effector?: Maybe<Effector>;
   effectors: Array<Effector>;
+  epochStatistic?: Maybe<EpochStatistic>;
+  epochStatistics: Array<EpochStatistic>;
   graphNetwork?: Maybe<GraphNetwork>;
   graphNetworks: Array<GraphNetwork>;
   offer?: Maybe<Offer>;
@@ -2697,6 +2824,24 @@ export type QueryEffectorsArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Effector_Filter>;
+};
+
+
+export type QueryEpochStatisticArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryEpochStatisticsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<EpochStatistic_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<EpochStatistic_Filter>;
 };
 
 
@@ -2989,8 +3134,6 @@ export type SubmittedProof_OrderBy =
   | 'capacityCommitment'
   | 'capacityCommitmentStatsPerEpoch'
   | 'capacityCommitmentStatsPerEpoch__activeUnitCount'
-  | 'capacityCommitmentStatsPerEpoch__blockNumberEnd'
-  | 'capacityCommitmentStatsPerEpoch__blockNumberStart'
   | 'capacityCommitmentStatsPerEpoch__computeUnitsWithMinRequiredProofsSubmittedCounter'
   | 'capacityCommitmentStatsPerEpoch__currentCCNextCCFailedEpoch'
   | 'capacityCommitmentStatsPerEpoch__epoch'
@@ -3022,6 +3165,7 @@ export type SubmittedProof_OrderBy =
   | 'capacityCommitment__totalFailCount'
   | 'computeUnit'
   | 'computeUnit__createdAt'
+  | 'computeUnit__deleted'
   | 'computeUnit__id'
   | 'computeUnit__submittedProofsCount'
   | 'computeUnit__workerId'
@@ -3073,6 +3217,8 @@ export type Subscription = {
   deals: Array<Deal>;
   effector?: Maybe<Effector>;
   effectors: Array<Effector>;
+  epochStatistic?: Maybe<EpochStatistic>;
+  epochStatistics: Array<EpochStatistic>;
   graphNetwork?: Maybe<GraphNetwork>;
   graphNetworks: Array<GraphNetwork>;
   offer?: Maybe<Offer>;
@@ -3290,6 +3436,24 @@ export type SubscriptionEffectorsArgs = {
   skip?: InputMaybe<Scalars['Int']['input']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Effector_Filter>;
+};
+
+
+export type SubscriptionEpochStatisticArgs = {
+  block?: InputMaybe<Block_Height>;
+  id: Scalars['ID']['input'];
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionEpochStatisticsArgs = {
+  block?: InputMaybe<Block_Height>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<EpochStatistic_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  subgraphError?: _SubgraphErrorPolicy_;
+  where?: InputMaybe<EpochStatistic_Filter>;
 };
 
 

--- a/ts-client/src/utils/indexerClient/serializers.ts
+++ b/ts-client/src/utils/indexerClient/serializers.ts
@@ -36,38 +36,43 @@ export function serializeEffectors(
     | Array<{ effector: { id: string; description: string } }>
     | null
     | undefined,
-): Array<{cid: string, description: string}> {
-  const composedEffectors: Array<{cid: string, description: string}> = [];
+): Array<{ cid: string; description: string }> {
+  const composedEffectors: Array<{ cid: string; description: string }> = [];
   if (!manyToManyEffectors) {
     return composedEffectors;
   }
   for (const effector of manyToManyEffectors) {
     composedEffectors.push({
       cid: effector.effector.id,
-      description: serializeEffectorDescription(
-        {
-          cid: effector.effector.id,
-          description: effector.effector.description,
-        }
-      ),
+      description: serializeEffectorDescription({
+        cid: effector.effector.id,
+        description: effector.effector.description,
+      }),
     });
   }
 
   return composedEffectors;
 }
 
-export function serializeEffectorDescription(
-  effectorIn: {cid: string, description: string},
-): string {
+export function serializeEffectorDescription(effectorIn: {
+  cid: string;
+  description: string;
+}): string {
   // Add custom serialization logic here.
   return effectorIn.description;
 }
 
 // Serialize contract Rate to Percentage Ratio in accordance with contract precision.
-export function serializeContractRateToPercentage(rate: number, precision: number): number {
-  return rate / precision * 100
+export function serializeContractRateToPercentage(
+  rate: number,
+  precision: number,
+): number {
+  return (rate / precision) * 100;
 }
 
-export function serializePercentageToContractRate(percentage: number, precision: number): number {
-  return Math.round(percentage / 100 * precision)
+export function serializePercentageToContractRate(
+  percentage: number,
+  precision: number,
+): number {
+  return Math.round((percentage / 100) * precision);
 }

--- a/ts-client/src/utils/rpcClientABC.ts
+++ b/ts-client/src/utils/rpcClientABC.ts
@@ -2,7 +2,7 @@ import type { Interface, Result, ethers } from "ethers";
 import { IMulticall3__factory, type IMulticall3 } from "../index.js";
 import { getLogger } from "./logger.js";
 
-const logger = getLogger("deal-ts-clients:rpcClientABC")
+const logger = getLogger("deal-ts-clients:rpcClientABC");
 
 export type Multicall3ContractCall = {
   target: string;
@@ -61,7 +61,9 @@ export abstract class Multicall3ContractClientABC {
     );
     const multicallContractCallResults: Aggregate3Response[] =
       await this._multicall3Contract.aggregate3.staticCall(callsEncoded);
-    logger.debug(`[_callBatch] Got: ${JSON.stringify(multicallContractCallResults)}`);
+    logger.debug(
+      `[_callBatch] Got: ${JSON.stringify(multicallContractCallResults)}`,
+    );
 
     let decodedResults: Array<any> = [];
     for (let i = 0; i < multicallContractCallResults.length; i++) {


### PR DESCRIPTION
# ChangeLog
- subgraph: support delete for CU and Peer models (mark as deleted). All `deleted` entities are now out of scope for all actual counters. Delete for Offer in separate PR
- all deal Clients: support new deleted=True in queries. In Matcher explicitly, in Cli and Explorer clients: on protocol level (directly in graph queries)
- fmt run

# ToDo
- [ ] redeploy subgraph
- [x] test on kras subgraph fork